### PR TITLE
refactor: Add MokksyDsl annotation for DSL scoping

### DIFF
--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -22,6 +22,9 @@ public final class dev/mokksy/mokksy/JournalMode : java/lang/Enum {
 	public static fun values ()[Ldev/mokksy/mokksy/JournalMode;
 }
 
+public abstract interface annotation class dev/mokksy/mokksy/MokksyDsl : java/lang/annotation/Annotation {
+}
+
 public final class dev/mokksy/mokksy/MokksyJava {
 	public static final fun respondsWith (Ldev/mokksy/mokksy/BuildingStep;Ljava/lang/Class;Ljava/util/function/Consumer;)V
 	public static final fun respondsWithStream (Ldev/mokksy/mokksy/BuildingStep;Ljava/lang/Class;Ljava/util/function/Consumer;)V

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <dev.mokksy:mokksy>
+open annotation class dev.mokksy.mokksy/MokksyDsl : kotlin/Annotation { // dev.mokksy.mokksy/MokksyDsl|null[0]
+    constructor <init>() // dev.mokksy.mokksy/MokksyDsl.<init>|<init>(){}[0]
+}
+
 final enum class dev.mokksy.mokksy.utils.highlight/AnsiColor : kotlin/Enum<dev.mokksy.mokksy.utils.highlight/AnsiColor> { // dev.mokksy.mokksy.utils.highlight/AnsiColor|null[0]
     enum entry BLACK // dev.mokksy.mokksy.utils.highlight/AnsiColor.BLACK|null[0]
     enum entry BLUE // dev.mokksy.mokksy.utils.highlight/AnsiColor.BLUE|null[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyDsl.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyDsl.kt
@@ -1,0 +1,11 @@
+package dev.mokksy.mokksy
+
+/**
+ * DSL marker for the Mokksy stub-definition DSL.
+ *
+ * Prevents implicit access to outer DSL receiver scopes inside nested blocks.
+ * For example, [dev.mokksy.mokksy.request.RequestSpecificationBuilder] methods
+ * cannot be called from inside a `respondsWith { }` lambda, and vice versa.
+ */
+@DslMarker
+public annotation class MokksyDsl

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecification.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy.request
 
+import dev.mokksy.mokksy.MokksyDsl
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.string.contain
 import io.ktor.http.Headers
@@ -164,6 +165,7 @@ public open class RequestSpecification<P : Any>(
         }
 }
 
+@MokksyDsl
 public open class RequestSpecificationBuilder<P : Any>(
     protected val requestType: KClass<P>,
 ) {

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy.response
 
+import dev.mokksy.mokksy.MokksyDsl
 import dev.mokksy.mokksy.request.CapturedRequest
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.ContentType
@@ -19,6 +20,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * @property httpStatus The HTTP status code to be associated with the response.
  * @author Konstantin Pavlov
  */
+@MokksyDsl
 public abstract class AbstractResponseDefinitionBuilder<P, T>(
     public var delay: Duration = Duration.ZERO,
 ) {
@@ -145,6 +147,7 @@ public abstract class AbstractResponseDefinitionBuilder<P, T>(
  * Inherits functionality from [AbstractResponseDefinitionBuilder] to allow additional header manipulations
  * and provides a concrete implementation of the response building process.
  */
+@MokksyDsl
 @Suppress("LongParameterList")
 public open class ResponseDefinitionBuilder<P : Any, T : Any>(
     public val request: CapturedRequest<P>,
@@ -192,6 +195,7 @@ public open class ResponseDefinitionBuilder<P : Any, T : Any>(
  * @property chunks A list of data chunks to be sent as part of the stream,
  *          if [flow] is not provided.
  */
+@MokksyDsl
 @Suppress("LongParameterList")
 public open class StreamingResponseDefinitionBuilder<P : Any, T>(
     public val request: CapturedRequest<P>,


### PR DESCRIPTION
- Introduce `@MokksyDsl` annotation to enforce scoping restrictions within DSL blocks.
- Apply `@MokksyDsl` annotation to relevant builder classes in request and response packages.