### PR TITLE
fix: #61 colorize JSON response bodies for typed/ContentNegotiation responses

### DIFF
--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -277,17 +277,20 @@ public final class dev/mokksy/mokksy/ServerConfiguration {
 	public fun <init> (Z)V
 	public fun <init> (ZLjava/lang/String;)V
 	public fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;)V
-	public fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlinx/serialization/json/Json;)V
+	public fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/mokksy/mokksy/JournalMode;
-	public final fun component4 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/ServerConfiguration;
-	public static synthetic fun copy$default (Ldev/mokksy/mokksy/ServerConfiguration;ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/mokksy/mokksy/ServerConfiguration;
+	public final fun component4 ()Lkotlinx/serialization/json/Json;
+	public final fun component5 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/ServerConfiguration;
+	public static synthetic fun copy$default (Ldev/mokksy/mokksy/ServerConfiguration;ZLjava/lang/String;Ldev/mokksy/mokksy/JournalMode;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/mokksy/mokksy/ServerConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContentNegotiationConfigurer ()Lkotlin/jvm/functions/Function1;
 	public final fun getJournalMode ()Ldev/mokksy/mokksy/JournalMode;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getVerbose ()Z
 	public fun hashCode ()I
@@ -542,15 +545,17 @@ public final class dev/mokksy/mokksy/utils/highlight/ColorTheme : java/lang/Enum
 public final class dev/mokksy/mokksy/utils/highlight/Highlighting {
 	public static final field INSTANCE Ldev/mokksy/mokksy/utils/highlight/Highlighting;
 	public final fun highlightBody (Ljava/lang/String;Lio/ktor/http/ContentType;Z)Ljava/lang/String;
+	public final fun highlightBody (Lkotlinx/serialization/json/JsonElement;Z)Ljava/lang/String;
 	public static synthetic fun highlightBody$default (Ldev/mokksy/mokksy/utils/highlight/Highlighting;Ljava/lang/String;Lio/ktor/http/ContentType;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun highlightBody$default (Ldev/mokksy/mokksy/utils/highlight/Highlighting;Lkotlinx/serialization/json/JsonElement;ZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public class dev/mokksy/mokksy/utils/logger/HttpFormatter {
 	public fun <init> ()V
-	public fun <init> (Ldev/mokksy/mokksy/utils/highlight/ColorTheme;Z)V
-	public synthetic fun <init> (Ldev/mokksy/mokksy/utils/highlight/ColorTheme;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun formatBody (Ljava/lang/String;Lio/ktor/http/ContentType;)Ljava/lang/String;
-	public static synthetic fun formatBody$default (Ldev/mokksy/mokksy/utils/logger/HttpFormatter;Ljava/lang/String;Lio/ktor/http/ContentType;ILjava/lang/Object;)Ljava/lang/String;
+	public fun <init> (Ldev/mokksy/mokksy/utils/highlight/ColorTheme;ZLkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Ldev/mokksy/mokksy/utils/highlight/ColorTheme;ZLkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun formatBody (Ljava/lang/Object;Lio/ktor/http/ContentType;)Ljava/lang/String;
+	public static synthetic fun formatBody$default (Ldev/mokksy/mokksy/utils/logger/HttpFormatter;Ljava/lang/Object;Lio/ktor/http/ContentType;ILjava/lang/Object;)Ljava/lang/String;
 	protected final fun getColors ()Ldev/mokksy/mokksy/utils/logger/HttpFormatter$ColorScheme;
 	protected final fun getUseColor ()Z
 	public final fun header (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -213,12 +213,14 @@ final class dev.mokksy.mokksy/MokksyServer : dev.mokksy.mokksy/MokksyHandler { /
 }
 
 final class dev.mokksy.mokksy/ServerConfiguration { // dev.mokksy.mokksy/ServerConfiguration|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/String? = ..., dev.mokksy.mokksy/JournalMode = ..., kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> = ...) // dev.mokksy.mokksy/ServerConfiguration.<init>|<init>(kotlin.Boolean;kotlin.String?;dev.mokksy.mokksy.JournalMode;kotlin.Function1<io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig,kotlin.Unit>){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/String? = ..., dev.mokksy.mokksy/JournalMode = ..., kotlinx.serialization.json/Json = ..., kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> = ...) // dev.mokksy.mokksy/ServerConfiguration.<init>|<init>(kotlin.Boolean;kotlin.String?;dev.mokksy.mokksy.JournalMode;kotlinx.serialization.json.Json;kotlin.Function1<io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig,kotlin.Unit>){}[0]
 
     final val contentNegotiationConfigurer // dev.mokksy.mokksy/ServerConfiguration.contentNegotiationConfigurer|{}contentNegotiationConfigurer[0]
         final fun <get-contentNegotiationConfigurer>(): kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> // dev.mokksy.mokksy/ServerConfiguration.contentNegotiationConfigurer.<get-contentNegotiationConfigurer>|<get-contentNegotiationConfigurer>(){}[0]
     final val journalMode // dev.mokksy.mokksy/ServerConfiguration.journalMode|{}journalMode[0]
         final fun <get-journalMode>(): dev.mokksy.mokksy/JournalMode // dev.mokksy.mokksy/ServerConfiguration.journalMode.<get-journalMode>|<get-journalMode>(){}[0]
+    final val json // dev.mokksy.mokksy/ServerConfiguration.json|{}json[0]
+        final fun <get-json>(): kotlinx.serialization.json/Json // dev.mokksy.mokksy/ServerConfiguration.json.<get-json>|<get-json>(){}[0]
     final val name // dev.mokksy.mokksy/ServerConfiguration.name|{}name[0]
         final fun <get-name>(): kotlin/String? // dev.mokksy.mokksy/ServerConfiguration.name.<get-name>|<get-name>(){}[0]
     final val verbose // dev.mokksy.mokksy/ServerConfiguration.verbose|{}verbose[0]
@@ -227,8 +229,9 @@ final class dev.mokksy.mokksy/ServerConfiguration { // dev.mokksy.mokksy/ServerC
     final fun component1(): kotlin/Boolean // dev.mokksy.mokksy/ServerConfiguration.component1|component1(){}[0]
     final fun component2(): kotlin/String? // dev.mokksy.mokksy/ServerConfiguration.component2|component2(){}[0]
     final fun component3(): dev.mokksy.mokksy/JournalMode // dev.mokksy.mokksy/ServerConfiguration.component3|component3(){}[0]
-    final fun component4(): kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> // dev.mokksy.mokksy/ServerConfiguration.component4|component4(){}[0]
-    final fun copy(kotlin/Boolean = ..., kotlin/String? = ..., dev.mokksy.mokksy/JournalMode = ..., kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> = ...): dev.mokksy.mokksy/ServerConfiguration // dev.mokksy.mokksy/ServerConfiguration.copy|copy(kotlin.Boolean;kotlin.String?;dev.mokksy.mokksy.JournalMode;kotlin.Function1<io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig,kotlin.Unit>){}[0]
+    final fun component4(): kotlinx.serialization.json/Json // dev.mokksy.mokksy/ServerConfiguration.component4|component4(){}[0]
+    final fun component5(): kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> // dev.mokksy.mokksy/ServerConfiguration.component5|component5(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/String? = ..., dev.mokksy.mokksy/JournalMode = ..., kotlinx.serialization.json/Json = ..., kotlin/Function1<io.ktor.server.plugins.contentnegotiation/ContentNegotiationConfig, kotlin/Unit> = ...): dev.mokksy.mokksy/ServerConfiguration // dev.mokksy.mokksy/ServerConfiguration.copy|copy(kotlin.Boolean;kotlin.String?;dev.mokksy.mokksy.JournalMode;kotlinx.serialization.json.Json;kotlin.Function1<io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig,kotlin.Unit>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // dev.mokksy.mokksy/ServerConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // dev.mokksy.mokksy/ServerConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // dev.mokksy.mokksy/ServerConfiguration.toString|toString(){}[0]
@@ -371,14 +374,14 @@ open class <#A: kotlin/Any?> dev.mokksy.mokksy.response/SseStreamResponseDefinit
 }
 
 open class dev.mokksy.mokksy.utils.logger/HttpFormatter { // dev.mokksy.mokksy.utils.logger/HttpFormatter|null[0]
-    constructor <init>(dev.mokksy.mokksy.utils.highlight/ColorTheme = ..., kotlin/Boolean = ...) // dev.mokksy.mokksy.utils.logger/HttpFormatter.<init>|<init>(dev.mokksy.mokksy.utils.highlight.ColorTheme;kotlin.Boolean){}[0]
+    constructor <init>(dev.mokksy.mokksy.utils.highlight/ColorTheme = ..., kotlin/Boolean = ..., kotlinx.serialization.json/Json = ...) // dev.mokksy.mokksy.utils.logger/HttpFormatter.<init>|<init>(dev.mokksy.mokksy.utils.highlight.ColorTheme;kotlin.Boolean;kotlinx.serialization.json.Json){}[0]
 
     final val colors // dev.mokksy.mokksy.utils.logger/HttpFormatter.colors|{}colors[0]
         final fun <get-colors>(): dev.mokksy.mokksy.utils.logger/HttpFormatter.ColorScheme // dev.mokksy.mokksy.utils.logger/HttpFormatter.colors.<get-colors>|<get-colors>(){}[0]
     final val useColor // dev.mokksy.mokksy.utils.logger/HttpFormatter.useColor|{}useColor[0]
         final fun <get-useColor>(): kotlin/Boolean // dev.mokksy.mokksy.utils.logger/HttpFormatter.useColor.<get-useColor>|<get-useColor>(){}[0]
 
-    final fun formatBody(kotlin/String?, io.ktor.http/ContentType = ...): kotlin/String // dev.mokksy.mokksy.utils.logger/HttpFormatter.formatBody|formatBody(kotlin.String?;io.ktor.http.ContentType){}[0]
+    final fun formatBody(kotlin/Any?, io.ktor.http/ContentType = ...): kotlin/String // dev.mokksy.mokksy.utils.logger/HttpFormatter.formatBody|formatBody(kotlin.Any?;io.ktor.http.ContentType){}[0]
     final fun header(kotlin/String, kotlin.collections/List<kotlin/String>): kotlin/String // dev.mokksy.mokksy.utils.logger/HttpFormatter.header|header(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
     final fun requestLine(io.ktor.http/HttpMethod, kotlin/String): kotlin/String // dev.mokksy.mokksy.utils.logger/HttpFormatter.requestLine|requestLine(io.ktor.http.HttpMethod;kotlin.String){}[0]
     final fun responseLine(kotlin/String, io.ktor.http/HttpStatusCode): kotlin/String // dev.mokksy.mokksy.utils.logger/HttpFormatter.responseLine|responseLine(kotlin.String;io.ktor.http.HttpStatusCode){}[0]
@@ -408,6 +411,7 @@ open class dev.mokksy.mokksy.utils.logger/HttpFormatter { // dev.mokksy.mokksy.u
 
 final object dev.mokksy.mokksy.utils.highlight/Highlighting { // dev.mokksy.mokksy.utils.highlight/Highlighting|null[0]
     final fun highlightBody(kotlin/String, io.ktor.http/ContentType, kotlin/Boolean = ...): kotlin/String // dev.mokksy.mokksy.utils.highlight/Highlighting.highlightBody|highlightBody(kotlin.String;io.ktor.http.ContentType;kotlin.Boolean){}[0]
+    final fun highlightBody(kotlinx.serialization.json/JsonElement, kotlin/Boolean = ...): kotlin/String // dev.mokksy.mokksy.utils.highlight/Highlighting.highlightBody|highlightBody(kotlinx.serialization.json.JsonElement;kotlin.Boolean){}[0]
 }
 
 final const val dev.mokksy.mokksy.request/DEFAULT_STUB_PRIORITY // dev.mokksy.mokksy.request/DEFAULT_STUB_PRIORITY|{}DEFAULT_STUB_PRIORITY[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
@@ -16,34 +16,18 @@ import io.ktor.http.HttpMethod.Companion.Options
 import io.ktor.http.HttpMethod.Companion.Patch
 import io.ktor.http.HttpMethod.Companion.Post
 import io.ktor.http.HttpMethod.Companion.Put
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 import io.ktor.server.routing.RoutingContext
 import io.ktor.util.logging.Logger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.serialization.json.Json
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
 import kotlin.reflect.KClass
 
-/**
- * Configures JSON content negotiation with `Json.ignoreUnknownKeys` enabled.
- * Used as the default [ServerConfiguration.contentNegotiationConfigurer].
- *
- * @param config The [ContentNegotiationConfig] to configure.
- */
-internal fun configureContentNegotiation(config: ContentNegotiationConfig) {
-    config.json(
-        Json {
-            ignoreUnknownKeys = true
-        },
-    )
-}
 
 /**
  * An embedded mock HTTP server for testing. Registers stubs for any HTTP method and verifies
@@ -105,7 +89,7 @@ public class MokksyServer
         private val resolvedPort: AtomicInt = AtomicInt(-1)
 
         private lateinit var logger: Logger
-        internal val httpFormatter: HttpFormatter = HttpFormatter()
+        internal val httpFormatter: HttpFormatter = HttpFormatter(json = configuration.json)
 
         private val stubRegistry: StubRegistry = StubRegistry()
         private val requestJournal: RequestJournal =

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
@@ -1,6 +1,8 @@
 package dev.mokksy.mokksy
 
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
+import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmOverloads
 
 /**
@@ -28,8 +30,12 @@ public enum class JournalMode {
  * @property journalMode Controls which requests are recorded in the
  *                       [dev.mokksy.mokksy.request.RequestJournal].
  *                       Defaults to [JournalMode.LEAN] (only unmatched requests).
+ * @property json The [Json] instance used for both content negotiation and response body logging.
+ *               Defaults to `Json { ignoreUnknownKeys = true }`. Provide a custom instance to
+ *               share serializers modules (e.g. for polymorphic types) between deserialization
+ *               and the verbose debug formatter.
  * @property contentNegotiationConfigurer Configures the Ktor [ContentNegotiationConfig] installed on the server.
- *                                        Defaults to JSON with [Json.ignoreUnknownKeys] enabled.
+ *                                        Defaults to installing [json] as the JSON codec.
  */
 public data class ServerConfiguration
     @JvmOverloads
@@ -37,7 +43,8 @@ public data class ServerConfiguration
         val verbose: Boolean = false,
         val name: String? = "Mokksy",
         val journalMode: JournalMode = JournalMode.LEAN,
+        val json: Json = Json { ignoreUnknownKeys = true },
         val contentNegotiationConfigurer: (
             ContentNegotiationConfig,
-        ) -> Unit = ::configureContentNegotiation,
+        ) -> Unit = { it.json(json) },
     )

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecificationMatching.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecificationMatching.kt
@@ -116,11 +116,11 @@ private suspend fun <P : Any> RequestSpecification<P>.receiveBodyOrNull(
         throw e
     } catch (e: ContentTransformationException) {
         request.call.application.log
-            .debug("Unable to read typed body for scoring: ${e.message}", e)
+            .trace("Unable to read typed body for scoring: ${e.message}")
         null
     } catch (e: BadRequestException) {
         request.call.application.log
-            .debug("Bad request body during scoring: ${e.message}", e)
+            .trace("Bad request body during scoring: ${e.message}")
         null
     }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
@@ -64,7 +64,7 @@ public open class ResponseDefinition<P, T>(
                         headers = call.response.headers,
                         contentType = this.contentType,
                         status = httpStatus,
-                        body = effectiveBody?.toString(),
+                        body = effectiveBody,
                     )
                 }---\n",
             )

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
@@ -4,6 +4,7 @@ package dev.mokksy.mokksy.utils.highlight
 
 import dev.mokksy.mokksy.InternalMokksyApi
 import io.ktor.http.ContentType
+import kotlinx.serialization.json.JsonElement
 
 @InternalMokksyApi
 public object Highlighting {
@@ -22,7 +23,7 @@ public object Highlighting {
         when {
             contentType.match(ContentType.Application.Json) ||
                 contentType.contentSubtype.endsWith("+json", ignoreCase = true) -> {
-                JsonHighlighter.highlight(
+                JsonStringHighlighter.highlight(
                     json = body,
                     useColor = useColor,
                 )
@@ -39,6 +40,21 @@ public object Highlighting {
                 body.colorize(AnsiColor.LIGHT_GRAY, enabled = useColor)
             }
         }
+
+    /**
+     * Applies ANSI color highlighting to a [JsonElement] for terminal output.
+     *
+     * Produces pretty-printed output by walking the element tree directly —
+     * no intermediate JSON string, no heuristic scanning.
+     *
+     * @param body The [JsonElement] to highlight.
+     * @param useColor Whether to apply ANSI color codes.
+     * @return The highlighted JSON string.
+     */
+    public fun highlightBody(
+        body: JsonElement,
+        useColor: Boolean = isColorSupported(),
+    ): String = JsonElementHighlighter.highlight(body, useColor)
 }
 
 @InternalMokksyApi
@@ -81,4 +97,4 @@ public enum class AnsiColor(
 internal fun String.colorize(
     color: AnsiColor,
     enabled: Boolean = isColorSupported(),
-): String = if (enabled) "${color.code}$this${AnsiColor.RESET.code}" else this
+): String = if (enabled) "${AnsiColor.RESET.code}${color.code}$this${AnsiColor.RESET.code}" else this

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighter.kt
@@ -1,0 +1,124 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.utils.highlight
+
+import dev.mokksy.mokksy.InternalMokksyApi
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Syntax highlighter for [JsonElement] trees using ANSI colors.
+ *
+ * Produces pretty-printed, colorized JSON output by walking the element tree directly —
+ * no intermediate JSON string needed, no heuristic scanning.
+ * Keys are colored magenta, string values green, numeric values blue, and
+ * boolean/null values yellow.
+ */
+internal object JsonElementHighlighter {
+    private val keyColor = AnsiColor.MAGENTA
+    private val stringValColor = AnsiColor.GREEN
+    private val numberValColor = AnsiColor.BLUE
+    private val boolNullColor = AnsiColor.YELLOW
+
+    fun highlight(
+        element: JsonElement,
+        useColor: Boolean,
+    ): String = buildString { appendElement(element, useColor, 0) }
+
+    private fun StringBuilder.appendElement(
+        element: JsonElement,
+        useColor: Boolean,
+        depth: Int,
+    ) {
+        when (element) {
+            is JsonObject -> appendObject(element, useColor, depth)
+            is JsonArray -> appendArray(element, useColor, depth)
+            is JsonPrimitive -> appendPrimitive(element, useColor)
+        }
+    }
+
+    private fun StringBuilder.appendObject(
+        obj: JsonObject,
+        useColor: Boolean,
+        depth: Int,
+    ) {
+        append('{')
+        val entries = obj.entries.toList()
+        entries.forEachIndexed { i, (key, value) ->
+            appendLine()
+            indent(depth + 1)
+            appendKey(key, useColor)
+            append(": ")
+            appendElement(value, useColor, depth + 1)
+            if (i < entries.size - 1) append(',')
+        }
+        if (entries.isNotEmpty()) {
+            appendLine()
+            indent(depth)
+        }
+        append('}')
+    }
+
+    private fun StringBuilder.appendArray(
+        arr: JsonArray,
+        useColor: Boolean,
+        depth: Int,
+    ) {
+        append('[')
+        arr.forEachIndexed { i, element ->
+            appendLine()
+            indent(depth + 1)
+            appendElement(element, useColor, depth + 1)
+            if (i < arr.size - 1) append(',')
+        }
+        if (arr.isNotEmpty()) {
+            appendLine()
+            indent(depth)
+        }
+        append(']')
+    }
+
+    private fun StringBuilder.appendPrimitive(
+        primitive: JsonPrimitive,
+        useColor: Boolean,
+    ) {
+        val color =
+            when {
+                primitive is JsonNull -> boolNullColor
+                primitive.isString -> stringValColor
+                primitive.content == "true" || primitive.content == "false" -> boolNullColor
+                else -> numberValColor
+            }
+        colorize(primitive.toString(), color, useColor)
+    }
+
+    private fun StringBuilder.appendKey(
+        key: String,
+        useColor: Boolean,
+    ) {
+        // JsonPrimitive(key).toString() produces a properly quoted and escaped JSON string
+        colorize(JsonPrimitive(key).toString(), keyColor, useColor)
+    }
+
+    private fun StringBuilder.indent(depth: Int) {
+        repeat(depth) { append("    ") }
+    }
+
+    private fun StringBuilder.colorize(
+        text: String,
+        color: AnsiColor,
+        useColor: Boolean,
+    ) {
+        if (useColor) {
+            append(AnsiColor.RESET.code)
+            append(color.code)
+            append(text)
+            append(AnsiColor.RESET.code)
+        } else {
+            append(text)
+        }
+    }
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighter.kt
@@ -12,7 +12,7 @@ import kotlin.jvm.JvmStatic
  * Suppressing TooManyFunctions as splitting would fragment the logic unnecessarily.
  */
 @Suppress("TooManyFunctions")
-internal object JsonHighlighter {
+internal object JsonStringHighlighter {
     private const val INITIAL_BUFFER_PADDING = 200
     private const val TRUE_NULL_LENGTH = 4
     private const val FALSE_LENGTH = 5
@@ -68,6 +68,7 @@ internal object JsonHighlighter {
         ) {
             if (buffer.isNotEmpty()) {
                 if (color != null) {
+                    result.append(AnsiColor.RESET.code)
                     result.append(color.code)
                     result.append(buffer)
                     result.append(AnsiColor.RESET.code)

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
@@ -17,6 +17,13 @@ import io.ktor.server.request.receiveText
 import io.ktor.server.request.uri
 import io.ktor.server.response.ResponseHeaders
 import io.ktor.server.routing.RoutingRequest
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializerOrNull
+
+private val DefaultJson = Json { ignoreUnknownKeys = true }
 
 /**
  * A utility class to format HTTP requests and responses into colorized strings for better readability.
@@ -26,11 +33,15 @@ import io.ktor.server.routing.RoutingRequest
  *
  * @param theme The color theme to be applied for formatting.
  * @param useColor Boolean flag indicating whether ANSI color codes should be used in the formatting output.
+ * @param json The [Json] instance used to encode typed response bodies for display.
+ *             Should match the instance used by Ktor's ContentNegotiation so that custom
+ *             [kotlinx.serialization.modules.SerializersModule] registrations are reflected in logs.
  */
 @InternalMokksyApi
 public open class HttpFormatter(
     theme: ColorTheme = ColorTheme.LIGHT_ON_DARK,
     protected val useColor: Boolean = isColorSupported(),
+    private val json: Json = DefaultJson,
 ) {
     /**
      * Returns the HTTP method name colorized according to its type and the current color settings.
@@ -116,23 +127,51 @@ public open class HttpFormatter(
         }"
 
     /**
-     * Formats the HTTP request body, applying syntax highlighting if color output is enabled.
+     * Formats the HTTP body for display, applying syntax highlighting if color output is enabled.
      *
-     * Returns an empty string if the body is null or blank.
-     * If color output is enabled, the body is highlighted according to its content type;
-     * otherwise, the raw body string is returned.
+     * Accepts any body type:
+     * - [String] bodies are highlighted using the string-based JSON/form highlighter.
+     * - [JsonElement] bodies are highlighted via the element tree highlighter (no intermediate string).
+     * - Typed objects with a JSON [contentType] are encoded to [JsonElement] first if a serializer
+     *   is available, then highlighted via the element tree highlighter.
+     * - All other cases fall back to [Any.toString].
      *
-     * @param body The HTTP request body to format.
+     * Returns an empty string if [body] is null or blank.
+     *
+     * @param body The HTTP body to format.
      * @param contentType The content type of the body, used for syntax highlighting.
      * @return The formatted body string, or an empty string if the body is null or blank.
      */
+    @Suppress("ReturnCount")
     public fun formatBody(
-        body: String?,
+        body: Any?,
         contentType: ContentType = ContentType.Any,
-    ): String {
-        if (body.isNullOrBlank()) return ""
-        return if (useColor) highlightBody(body, contentType) else body
-    }
+    ): String =
+        when (body) {
+            null -> {
+                ""
+            }
+
+            is String if body.isBlank() -> {
+                ""
+            }
+
+            is String -> {
+                if (useColor) highlightBody(body, contentType) else body
+            }
+
+            is JsonElement -> {
+                highlightBody(body, useColor)
+            }
+
+            else -> {
+                val isJson =
+                    contentType.match(ContentType.Application.Json) ||
+                        contentType.contentSubtype.endsWith("+json", ignoreCase = true)
+                val jsonElement = if (isJson) tryEncodeToJsonElement(body) else null
+                jsonElement?.let { highlightBody(it, useColor) } ?: body.toString()
+            }
+        }
 
     /**
      * Formats an HTTP request into a colorized, multi-line string representation.
@@ -171,7 +210,7 @@ public open class HttpFormatter(
         httpVersion: String,
         status: HttpStatusCode,
         headers: ResponseHeaders,
-        body: String?,
+        body: Any?,
         contentType: ContentType,
     ): String =
         buildString {
@@ -187,6 +226,14 @@ public open class HttpFormatter(
         if (chunk.isNullOrBlank()) return ""
         return if (useColor) highlightBody(chunk, contentType) else chunk
     }
+
+    @OptIn(InternalSerializationApi::class)
+    @Suppress("UNCHECKED_CAST")
+    private fun tryEncodeToJsonElement(body: Any): JsonElement? =
+        runCatching {
+            val serializer = body::class.serializerOrNull() ?: return null
+            json.encodeToJsonElement(serializer as KSerializer<Any>, body)
+        }.getOrNull()
 
     @InternalMokksyApi
     public data class ColorScheme(

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighterTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighterTest.kt
@@ -1,0 +1,119 @@
+package dev.mokksy.mokksy.utils.highlight
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+private const val RESET = "\u001B[0m"
+private const val MAGENTA = "\u001B[35m"
+private const val GREEN = "\u001B[32m"
+private const val BLUE = "\u001B[34m"
+private const val YELLOW = "\u001B[33m"
+
+// Each colorized fragment is preceded by a reset to clear any preceding attributes.
+private val RM = "$RESET$MAGENTA"
+private val RG = "$RESET$GREEN"
+private val RB = "$RESET$BLUE"
+private val RY = "$RESET$YELLOW"
+
+class JsonElementHighlighterTest {
+    @Test
+    fun `Should highlight simple object`() {
+        val element = JsonObject(mapOf("foo" to JsonPrimitive("bar")))
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{\n    ${RM}\"foo\"$RESET: ${RG}\"bar\"$RESET\n}"
+    }
+
+    @Test
+    fun `Should highlight object with number value`() {
+        val element = JsonObject(mapOf("count" to JsonPrimitive(42)))
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{\n    ${RM}\"count\"$RESET: ${RB}42$RESET\n}"
+    }
+
+    @Test
+    fun `Should highlight object with boolean value`() {
+        val element = JsonObject(mapOf("flag" to JsonPrimitive(true)))
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{\n    ${RM}\"flag\"$RESET: ${RY}true$RESET\n}"
+    }
+
+    @Test
+    fun `Should highlight object with null value`() {
+        val element = JsonObject(mapOf("value" to JsonNull))
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{\n    ${RM}\"value\"$RESET: ${RY}null$RESET\n}"
+    }
+
+    @Test
+    fun `Should highlight nested object`() {
+        val element =
+            JsonObject(
+                mapOf("outer" to JsonObject(mapOf("inner" to JsonPrimitive("val")))),
+            )
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe
+            "{\n    ${RM}\"outer\"$RESET: {\n        ${RM}\"inner\"$RESET: ${RG}\"val\"$RESET\n    }\n}"
+    }
+
+    @Test
+    fun `Should highlight array of primitives`() {
+        val element =
+            JsonObject(
+                mapOf(
+                    "items" to
+                        JsonArray(
+                            listOf(JsonPrimitive("a"), JsonPrimitive("b")),
+                        ),
+                ),
+            )
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe
+            "{\n    ${RM}\"items\"$RESET: [\n        ${RG}\"a\"$RESET,\n        ${RG}\"b\"$RESET\n    ]\n}"
+    }
+
+    @Test
+    fun `Should escape special characters in keys`() {
+        val element = JsonObject(mapOf("ba\"z" to JsonPrimitive(1)))
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{\n    ${RM}\"ba\\\"z\"$RESET: ${RB}1$RESET\n}"
+    }
+
+    @Test
+    fun `Should produce plain output when color disabled`() {
+        val element = JsonObject(mapOf("foo" to JsonPrimitive("bar")))
+        val result = JsonElementHighlighter.highlight(element, useColor = false)
+        result shouldBe "{\n    \"foo\": \"bar\"\n}"
+    }
+
+    @Test
+    fun `Should highlight empty object`() {
+        val element = JsonObject(emptyMap())
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "{}"
+    }
+
+    @Test
+    fun `Should highlight empty array`() {
+        val element = JsonArray(emptyList())
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe "[]"
+    }
+
+    @Test
+    fun `Should highlight multiple fields`() {
+        val element =
+            JsonObject(
+                mapOf(
+                    "name" to JsonPrimitive("Alice"),
+                    "age" to JsonPrimitive(30),
+                ),
+            )
+        val result = JsonElementHighlighter.highlight(element, useColor = true)
+        result shouldBe
+            "{\n    ${RM}\"name\"$RESET: ${RG}\"Alice\"$RESET,\n    ${RM}\"age\"$RESET: ${RB}30$RESET\n}"
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighterTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighterTest.kt
@@ -12,55 +12,61 @@ private const val GREEN = "\u001B[32m"
 private const val BLUE = "\u001B[34m"
 private const val YELLOW = "\u001B[33m"
 
+// Each colorized fragment is preceded by a reset to clear any preceding attributes.
+private val RM = "$RESET$MAGENTA"
+private val RG = "$RESET$GREEN"
+private val RB = "$RESET$BLUE"
+private val RY = "$RESET$YELLOW"
+
 @Suppress("MaxLineLength")
-class JsonHighlighterTest {
+class JsonStringHighlighterTest {
     @Test
     fun `Should highlight simple Json`() {
         // language=json
         val input = """{"foo": "bar", "ba\"z": 1}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
         result shouldBe
-            "{$MAGENTA\"foo\"$RESET: $GREEN\"bar\"$RESET, $MAGENTA\"ba\\\"z\"$RESET: ${BLUE}1$RESET}"
+            "{${RM}\"foo\"$RESET: ${RG}\"bar\"$RESET, ${RM}\"ba\\\"z\"$RESET: ${RB}1$RESET}"
     }
 
     @Test
     fun `Should highlight Json with newline`() {
         // language=json
         val input = "{\n  \"foo\"\n  : \n  \"bar\"\n}"
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
         result shouldBe
-            "{\n  $MAGENTA\"foo\"$RESET\n  : \n  $GREEN\"bar\"$RESET\n}"
+            "{\n  ${RM}\"foo\"$RESET\n  : \n  ${RG}\"bar\"$RESET\n}"
     }
 
     @Test
     fun `Should highlight nested Json`() {
         // language=json
         val input = """{"foo": {"bar": "ba\"z"}}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
-        result shouldBe "{$MAGENTA\"foo\"$RESET: {$MAGENTA\"bar\"$RESET: $GREEN\"ba\\\"z\"$RESET}}"
+        result shouldBe "{${RM}\"foo\"$RESET: {${RM}\"bar\"$RESET: ${RG}\"ba\\\"z\"$RESET}}"
     }
 
     @Test
     fun `Should highlight Json with array`() {
         // language=json
         val input = """{"foo": ["bar", "ba\"z"]}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
         result shouldBe
-            "{$MAGENTA\"foo\"$RESET: [$GREEN\"bar\"$RESET, $GREEN\"ba\\\"z\"$RESET]}"
+            "{${RM}\"foo\"$RESET: [${RG}\"bar\"$RESET, ${RG}\"ba\\\"z\"$RESET]}"
     }
 
     @Test
     fun `Should highlight Json with array of objects`() {
         // language=json
         val input = """{"foo": [{"bar": "baz"}]}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
         result shouldBe
-            "{$MAGENTA\"foo\"$RESET: [{$MAGENTA\"bar\"$RESET: $GREEN\"baz\"$RESET}]}"
+            "{${RM}\"foo\"$RESET: [{${RM}\"bar\"$RESET: ${RG}\"baz\"$RESET}]}"
     }
 
     @ParameterizedTest
@@ -82,9 +88,9 @@ class JsonHighlighterTest {
     fun `Should highlight different number types`(numberValue: String) {
         // language=json
         val input = """{"number": $numberValue}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
-        result shouldBe "{$MAGENTA\"number\"$RESET: $BLUE$numberValue$RESET}"
+        result shouldBe "{${RM}\"number\"$RESET: $RB$numberValue$RESET}"
     }
 
     @ParameterizedTest
@@ -92,18 +98,18 @@ class JsonHighlighterTest {
     fun `Should highlight boolean value`(value: Boolean) {
         // language=json
         val input = """{"flag": $value}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
-        result shouldBe "{$MAGENTA\"flag\"$RESET: ${YELLOW}$value$RESET}"
+        result shouldBe "{${RM}\"flag\"$RESET: ${RY}$value$RESET}"
     }
 
     @Test
     fun `Should highlight null value`() {
         // language=json
         val input = """{"value": null}"""
-        val result = JsonHighlighter.highlight(input, useColor = true)
+        val result = JsonStringHighlighter.highlight(input, useColor = true)
         // language=text
-        result shouldBe "{$MAGENTA\"value\"$RESET: ${YELLOW}null$RESET}"
+        result shouldBe "{${RM}\"value\"$RESET: ${RY}null$RESET}"
     }
 
     @ParameterizedTest
@@ -118,8 +124,8 @@ class JsonHighlighterTest {
     ) {
         // language=json
         val input = """{"values": [$value1, $value1]}"""
-        val result = JsonHighlighter.highlight(json = input, useColor = true)
+        val result = JsonStringHighlighter.highlight(json = input, useColor = true)
         // language=text
-        result shouldBe "{$MAGENTA\"values\"$RESET: [$YELLOW$value2$RESET, $YELLOW$value2$RESET]}"
+        result shouldBe "{${RM}\"values\"$RESET: [${RY}$value2$RESET, ${RY}$value2$RESET]}"
     }
 }

--- a/mokksy/src/jvmTest/resources/simplelogger.properties
+++ b/mokksy/src/jvmTest/resources/simplelogger.properties
@@ -3,6 +3,7 @@ org.slf4j.simpleLogger.defaultLogLevel=INFO
 # Log level for specific packages or classes (optional)
 org.slf4j.simpleLogger.log.dev.mokksy=TRACE
 org.slf4j.simpleLogger.log.io.ktor.server=DEBUG
+org.slf4j.simpleLogger.log.io.netty.channel.AbstractChannelHandlerContext=ERROR
 # Whether to show the logging level (true/false)
 # Whether to display the thread name in log messages (true/false)
 org.slf4j.simpleLogger.showThreadName=true


### PR DESCRIPTION
 ## Problem (#61)

  Verbose logging displayed raw `toString()` output for typed response bodies when ContentNegotiation was used — e.g. `Output(result=Hello, R2-a2!)` — instead of colorized, pretty-printed JSON.

  Root cause: `formatter.formatResponse()` was called without a `contentType` argument, so the formatter fell through to `body.toString()` for any non-String, non-JsonElement body.

  ## Changes

  - **`ResponseDefinition`** — pass `this.contentType` to `formatResponse()`
  - **`JsonElementHighlighter`** (new) — tree-walking highlighter for `JsonElement`; replaces heuristic string scanning for typed bodies, with full test coverage in `commonTest`
  - **`JsonHighlighter` → `JsonStringHighlighter`** — rename to clarify the two highlighters serve different input types
  - **`Highlighting`** — add `highlightBody(JsonElement)` overload
  - **`HttpFormatter.formatBody`** — new dispatch: `String` → string highlighter, `JsonElement` → element highlighter, typed object with JSON content type → serialize to `JsonElement` via the configured `Json`, fall back to `toString()`
  - **`ServerConfiguration`** — add `json: Json` property (default: `Json { ignoreUnknownKeys = true }`); the default `contentNegotiationConfigurer` now installs this same instance, so custom `SerializersModule` registrations are automatically reflected in verbose logs
