### PR TITLE
Fix compatibility with 0.8

### DIFF
--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -350,6 +350,7 @@ public final class dev/mokksy/mokksy/StubConfiguration : java/lang/Record {
 	public fun <init> (Ljava/lang/String;Z)V
 	public fun <init> (Ljava/lang/String;ZZ)V
 	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Z)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -734,9 +735,11 @@ public abstract class dev/mokksy/mokksy/response/AbstractResponseDefinitionBuild
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getDelay-UwyO8pc ()J
 	public final fun getHeaders ()Ldev/mokksy/mokksy/response/AbstractResponseDefinitionBuilder$HeadersConfigurer;
-	public fun getHttpStatus ()Lio/ktor/http/HttpStatusCode;
+	public final fun getHttpStatus ()Lio/ktor/http/HttpStatusCode;
+	public fun getHttpStatusCode ()I
 	public final fun setDelay-LRDsOJo (J)V
-	public fun setHttpStatus (Lio/ktor/http/HttpStatusCode;)V
+	public final fun setHttpStatus (Lio/ktor/http/HttpStatusCode;)V
+	public fun setHttpStatusCode (I)V
 }
 
 public final class dev/mokksy/mokksy/response/AbstractResponseDefinitionBuilder$HeadersConfigurer {
@@ -755,12 +758,12 @@ public class dev/mokksy/mokksy/response/ResponseDefinitionBuilder : dev/mokksy/m
 	public synthetic fun build$mokksy ()Ldev/mokksy/mokksy/response/AbstractResponseDefinition;
 	public final fun getBody ()Ljava/lang/Object;
 	public final fun getContentType ()Lio/ktor/http/ContentType;
-	public fun getHttpStatus ()Lio/ktor/http/HttpStatusCode;
+	public fun getHttpStatusCode ()I
 	public final fun getRequest ()Ldev/mokksy/mokksy/request/CapturedRequest;
 	public final fun header (Ljava/lang/String;Ljava/lang/String;)Ldev/mokksy/mokksy/response/ResponseDefinitionBuilder;
 	public final fun setBody (Ljava/lang/Object;)V
 	public final fun setContentType (Lio/ktor/http/ContentType;)V
-	public fun setHttpStatus (Lio/ktor/http/HttpStatusCode;)V
+	public fun setHttpStatusCode (I)V
 	public final fun status (I)Ldev/mokksy/mokksy/response/ResponseDefinitionBuilder;
 }
 

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -115,9 +115,12 @@ abstract class <#A: kotlin/Any?, #B: kotlin/Any?> dev.mokksy.mokksy.response/Abs
     final var delay // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.delay|{}delay[0]
         final fun <get-delay>(): kotlin.time/Duration // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.delay.<get-delay>|<get-delay>(){}[0]
         final fun <set-delay>(kotlin.time/Duration) // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.delay.<set-delay>|<set-delay>(kotlin.time.Duration){}[0]
-    open var httpStatus // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus|{}httpStatus[0]
-        open fun <get-httpStatus>(): io.ktor.http/HttpStatusCode // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus.<get-httpStatus>|<get-httpStatus>(){}[0]
-        open fun <set-httpStatus>(io.ktor.http/HttpStatusCode) // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus.<set-httpStatus>|<set-httpStatus>(io.ktor.http.HttpStatusCode){}[0]
+    final var httpStatus // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus|{}httpStatus[0]
+        final fun <get-httpStatus>(): io.ktor.http/HttpStatusCode // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus.<get-httpStatus>|<get-httpStatus>(){}[0]
+        final fun <set-httpStatus>(io.ktor.http/HttpStatusCode) // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatus.<set-httpStatus>|<set-httpStatus>(io.ktor.http.HttpStatusCode){}[0]
+    open var httpStatusCode // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatusCode|{}httpStatusCode[0]
+        open fun <get-httpStatusCode>(): kotlin/Int // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatusCode.<get-httpStatusCode>|<get-httpStatusCode>(){}[0]
+        open fun <set-httpStatusCode>(kotlin/Int) // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.httpStatusCode.<set-httpStatusCode>|<set-httpStatusCode>(kotlin.Int){}[0]
 
     final fun addHeader(kotlin/String, kotlin/String) // dev.mokksy.mokksy.response/AbstractResponseDefinitionBuilder.addHeader|addHeader(kotlin.String;kotlin.String){}[0]
 
@@ -460,6 +463,7 @@ final class dev.mokksy.mokksy/ServerConfiguration { // dev.mokksy.mokksy/ServerC
 }
 
 final class dev.mokksy.mokksy/StubConfiguration { // dev.mokksy.mokksy/StubConfiguration|null[0]
+    constructor <init>(kotlin/Boolean) // dev.mokksy.mokksy/StubConfiguration.<init>|<init>(kotlin.Boolean){}[0]
     constructor <init>(kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // dev.mokksy.mokksy/StubConfiguration.<init>|<init>(kotlin.String?;kotlin.Boolean;kotlin.Boolean){}[0]
 
     final val eventuallyRemove // dev.mokksy.mokksy/StubConfiguration.eventuallyRemove|{}eventuallyRemove[0]
@@ -495,9 +499,9 @@ open class <#A: kotlin/Any, #B: kotlin/Any> dev.mokksy.mokksy.response/ResponseD
     final var contentType // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.contentType|{}contentType[0]
         final fun <get-contentType>(): io.ktor.http/ContentType? // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.contentType.<get-contentType>|<get-contentType>(){}[0]
         final fun <set-contentType>(io.ktor.http/ContentType?) // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.contentType.<set-contentType>|<set-contentType>(io.ktor.http.ContentType?){}[0]
-    open var httpStatus // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatus|{}httpStatus[0]
-        open fun <get-httpStatus>(): io.ktor.http/HttpStatusCode // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatus.<get-httpStatus>|<get-httpStatus>(){}[0]
-        open fun <set-httpStatus>(io.ktor.http/HttpStatusCode) // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatus.<set-httpStatus>|<set-httpStatus>(io.ktor.http.HttpStatusCode){}[0]
+    open var httpStatusCode // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatusCode|{}httpStatusCode[0]
+        open fun <get-httpStatusCode>(): kotlin/Int // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatusCode.<get-httpStatusCode>|<get-httpStatusCode>(){}[0]
+        open fun <set-httpStatusCode>(kotlin/Int) // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.httpStatusCode.<set-httpStatusCode>|<set-httpStatusCode>(kotlin.Int){}[0]
 
     final fun body(#B): dev.mokksy.mokksy.response/ResponseDefinitionBuilder<#A, #B> // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.body|body(1:1){}[0]
     final fun header(kotlin/String, kotlin/String): dev.mokksy.mokksy.response/ResponseDefinitionBuilder<#A, #B> // dev.mokksy.mokksy.response/ResponseDefinitionBuilder.header|header(kotlin.String;kotlin.String){}[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
@@ -146,15 +146,16 @@ public class BuildingStep<P : Any> internal constructor(
     @Suppress("ThrowsCount")
     public infix fun <T : Any> respondsWithStream(
         block: suspend StreamingResponseDefinitionBuilder<P, T>.() -> Unit,
-    ): Unit = registerStreamingStub(
-        builderFactory = { req ->
-            StreamingResponseDefinitionBuilder(
-                request = req,
-                formatter = formatter
-            )
-        },
-        block = block,
-    )
+    ): Unit =
+        registerStreamingStub(
+            builderFactory = { req ->
+                StreamingResponseDefinitionBuilder(
+                    request = req,
+                    formatter = formatter,
+                )
+            },
+            block = block,
+        )
 
     /**
      * Associates the current [RequestSpecification] with a streaming response definition.
@@ -185,12 +186,13 @@ public class BuildingStep<P : Any> internal constructor(
      */
     public infix fun <T : Any> respondsWithSseStream(
         block: suspend StreamingResponseDefinitionBuilder<P, ServerSentEventMetadata<T>>.() -> Unit,
-    ): Unit = registerStreamingStub(
-        builderFactory = { req ->
-            SseStreamingResponseDefinitionBuilder<P, T>(request = req, formatter = formatter)
-        },
-        block = block,
-    )
+    ): Unit =
+        registerStreamingStub(
+            builderFactory = { req ->
+                SseStreamingResponseDefinitionBuilder(request = req, formatter = formatter)
+            },
+            block = block,
+        )
 
     /**
      * Associates the current [RequestSpecification] with an SSE streaming response definition.

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubConfiguration.kt
@@ -32,6 +32,7 @@ public data class StubConfiguration
          * Note: the named constructor argument `StubConfiguration(removeAfterMatch = …)` cannot be
          * preserved — use `StubConfiguration(eventuallyRemove = …)` or the companion factory
          * [StubConfiguration.removeAfterMatch] for a deprecated named-argument form.
+         * @deprecated Deprecated since 0.9.2
          */
         @Deprecated(
             "Renamed to eventuallyRemove",
@@ -46,6 +47,7 @@ public data class StubConfiguration
              * Creates a [StubConfiguration] that is removed after its first match.
              *
              * Java-friendly alternative to `StubConfiguration(eventuallyRemove = true)`:
+             *
              * ```java
              * mokksy.get(StubConfiguration.once("my-stub"), "/path")
              *     .respondsWith("one-time response");
@@ -84,6 +86,25 @@ public data class StubConfiguration
                     verbose = verbose,
                 )
         }
+
+        /**
+         * Secondary constructor for creating a [StubConfiguration] instance.
+         *
+         * This constructor is deprecated and should be replaced
+         * with the `StubConfiguration(eventuallyRemove)` constructor.
+         *
+         * @param removeAfterMatch Indicates whether the stub should be eventually removed after it has been matched.
+         * @deprecated Use `StubConfiguration(eventuallyRemove)` instead.
+         */
+        @Deprecated(
+            message = "Use StubConfiguration(eventuallyRemove = removeAfterMatch) instead",
+            replaceWith = ReplaceWith("StubConfiguration(eventuallyRemove = removeAfterMatch)"),
+        )
+        public constructor(
+            removeAfterMatch: Boolean,
+        ) : this(
+            eventuallyRemove = removeAfterMatch,
+        )
 
         override fun toString(): String =
             buildString {

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
@@ -22,17 +22,25 @@ import kotlinx.coroutines.flow.flow as buildFlow
  *
  * @param P The type of the request body, used to type the [CapturedRequest] available during building.
  * @param T The type of the response data, which is returned to the client.
- * @property httpStatus The HTTP status code to be associated with the response.
+ * @property httpStatusCode The HTTP status code to be associated with the response.
  * @author Konstantin Pavlov
  */
 @MokksyDsl
 public abstract class AbstractResponseDefinitionBuilder<P, T>(
     public var delay: Duration = Duration.ZERO,
 ) {
-    public open var httpStatus: HttpStatusCode = HttpStatusCode.OK
-
+    public open var httpStatusCode: Int = HttpStatusCode.OK.value
     private val headerPairs: MutableList<Pair<String, String>> = mutableListOf()
     private var headersLambda: (ResponseHeaders.() -> Unit)? = null
+
+    /**
+     * The HTTP status code of the response.
+     */
+    public var httpStatus: HttpStatusCode
+        get() = HttpStatusCode.fromValue(httpStatusCode)
+        set(value) {
+            httpStatusCode = value.value
+        }
 
     /**
      * Adds a single response header.
@@ -125,7 +133,8 @@ public abstract class AbstractResponseDefinitionBuilder<P, T>(
  * @property request The [CapturedRequest] being processed.
  * @property contentType Optional MIME type of the response. Defaults to `null` if not specified.
  * @property body The body of the response. Can be null.
- * @property httpStatus The HTTP status code of the response, defaulting to HttpStatusCode.OK.
+ * @property httpStatusCode The HTTP status code of the response as an [Int],
+ *  defaulting to [HttpStatusCode.OK]`.value` (200).
  *
  * Inherits functionality from [AbstractResponseDefinitionBuilder] to allow additional header manipulations
  * and provides a concrete implementation of the response building process.
@@ -136,10 +145,9 @@ public open class ResponseDefinitionBuilder<P : Any, T : Any> internal construct
     public val request: CapturedRequest<P>,
     public var contentType: ContentType? = null,
     public var body: T? = null,
-    public override var httpStatus: HttpStatusCode = HttpStatusCode.OK,
+    public override var httpStatusCode: Int = HttpStatusCode.OK.value,
     private val formatter: HttpFormatter,
 ) : AbstractResponseDefinitionBuilder<P, T>() {
-
     /**
      * Sets the response body and returns this builder for chaining.
      *

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubConfigurationTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubConfigurationTest.kt
@@ -36,7 +36,9 @@ class StubConfigurationTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `removeAfterMatch property delegates to eventuallyRemove`(value: Boolean) {
+        StubConfiguration(eventuallyRemove = value).eventuallyRemove shouldBe value
         StubConfiguration(eventuallyRemove = value).removeAfterMatch shouldBe value
+        StubConfiguration(removeAfterMatch = value).eventuallyRemove shouldBe value
     }
 
     // endregion

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinitionBuilderTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinitionBuilderTest.kt
@@ -24,7 +24,10 @@ class AbstractResponseDefinitionBuilderTest {
         val result = mutableListOf<String>()
         headersBlock?.invoke(
             object : ResponseHeaders() {
-                override fun engineAppendHeader(name: String, value: String) {
+                override fun engineAppendHeader(
+                    name: String,
+                    value: String,
+                ) {
                     result.add("$name=$value")
                 }
 
@@ -238,7 +241,11 @@ class AbstractResponseDefinitionBuilderTest {
                         )
                     val returned = builder.header("X-Result", "ok")
                     val definition = builder.build()
-                    call.respondText("${returned === builder}|${collectHeaders(definition.headers).joinToString()}")
+                    call.respondText(
+                        "${returned === builder}|${collectHeaders(
+                            definition.headers,
+                        ).joinToString()}",
+                    )
                 }
             }
 
@@ -294,6 +301,26 @@ class AbstractResponseDefinitionBuilderTest {
 
             val response = client.post("/test") { setBody("") }
             response.bodyAsText() shouldBe "404"
+        }
+
+    @Test
+    fun `httpStatusCode setter updates httpStatus`() =
+        testApplication {
+            routing {
+                post("/test") {
+                    val builder =
+                        ResponseDefinitionBuilder<String, String>(
+                            request = CapturedRequest(call.request, String::class),
+                            formatter = formatter,
+                        )
+                    builder.httpStatusCode = HttpStatusCode.ExpectationFailed.value
+
+                    call.respondText("${builder.httpStatus.value}")
+                }
+            }
+
+            val response = client.post("/test") { setBody("") }
+            response.bodyAsText() shouldBe "417"
         }
 
     // endregion


### PR DESCRIPTION
- Revert httpStatusCode field and related methods for integer-based HTTP status management
- Add deprecated secondary constructor `StubConfiguration(removeAfterMatch:Boolean)` constructor in `StubConfiguration` for compatibility