### PR TITLE
feat: Add file-based YAML configuration for mock stubs (#122)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build
 build:
 	@echo "🏗️ Building..."
+	@rm -rf kotlin-js-store
 	@./gradlew checkLegacyAbi build koverVerify koverXmlReport koverHtmlReport koverLog
 
 .PHONY: apidump

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ atomicfu = "0.32.1"
 assertk = "0.28.1"
 awaitility = "4.3.0"
 datafaker = "2.5.4"
-detekt = "2.0.0-alpha.2"
+detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
 finchly = "0.1.1"
 junit = "6.0.3"
@@ -24,6 +24,7 @@ nexusPublish = "2.0.0"
 openrewrite = "7.30.0"
 slf4j = "2.0.17"
 jansi = "2.4.3"
+kaml = "0.104.0"
 knit = "0.5.1"
 vanniktechMavenPublish = "0.36.0"
 
@@ -40,6 +41,7 @@ awaitility-kotlin = { group = "org.awaitility", name = "awaitility-kotlin", vers
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 finchly = { module = "me.kpavlov.finchly:finchly", version.ref = "finchly" }
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }

--- a/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaFileConfigIT.java
+++ b/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaFileConfigIT.java
@@ -1,0 +1,239 @@
+package dev.mokksy.it;
+
+import dev.mokksy.Mokksy;
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MokksyJavaFileConfigIT {
+
+    private final Mokksy mokksy = Mokksy.create();
+    private HttpClient httpClient;
+
+    @BeforeAll
+    void setUp() throws URISyntaxException {
+        var file = new File(getClass().getResource("/it-stubs.yaml").toURI());
+        mokksy.start();
+        mokksy.loadStubsFromFile(file);
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void tearDown() {
+        mokksy.shutdown();
+    }
+
+    // region plain responses
+
+    @Test
+    void get_returnsPlainResponseFromFileConfig() throws Exception {
+        var response = get("/ping");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("{\"response\":\"Pong\"}");
+    }
+
+    @Test
+    void post_withBodyMatch_returnsConfiguredStatusAndHeaders() throws Exception {
+        var response = post("/things", "{\"id\":\"42\"}");
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.body()).isEqualTo("{\"id\":\"42\",\"name\":\"thing-42\"}");
+        assertThat(response.headers().firstValue("Location")).hasValue("/things/42");
+        assertThat(response.headers().firstValue("Foo")).hasValue("bar");
+    }
+
+    @Test
+    void post_withoutBodyMatch_returns404() throws Exception {
+        var response = post("/things", "{\"id\":\"99\"}");
+
+        assertThat(response.statusCode()).isEqualTo(404);
+    }
+
+    @Test
+    void get_delayedStub_returnsResponse() throws Exception {
+        var response = get("/delayed");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("ok");
+    }
+
+    // endregion
+
+    // region SSE stream
+
+    @Test
+    void post_returnsSseStreamFromFileConfig() throws Exception {
+        var response = post("/sse", "");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Type")).hasValue("text/event-stream; charset=UTF-8");
+        assertThat(response.body()).isEqualTo("data: One\r\n\r\ndata: Two\r\n\r\n");
+    }
+
+    // endregion
+
+    // region plain text stream
+
+    @Test
+    void get_returnsPlainTextStreamFromFileConfig() throws Exception {
+        var response = get("/stream");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Type")).hasValue("text/plain; charset=UTF-8");
+        assertThat(response.body()).isEqualTo("Hello World");
+    }
+
+    // endregion
+
+    // region error cases
+
+    @Test
+    void loadStubsFromFile_failsWithClearMessageWhenFileMissing() {
+        try (var server = Mokksy.create()) {
+            var missing = new File("/nonexistent/path/stubs.yaml");
+
+            assertThatThrownBy(() -> server.loadStubsFromFile(missing))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not found")
+                .hasMessageContaining(missing.getAbsolutePath());
+        }
+    }
+
+    @Test
+    void loadStubsFromFile_failsWithClearMessageForInvalidYaml() throws IOException {
+        try (var server = Mokksy.create()) {
+            Path badYaml = Files.createTempFile("bad", ".yaml");
+            Files.writeString(badYaml, "stubs: [{ path: /x, response: { status: not-a-number } }]");
+
+            try {
+                assertThatThrownBy(() -> server.loadStubsFromFile(badYaml.toFile()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid YAML");
+            } finally {
+                Files.deleteIfExists(badYaml);
+            }
+        }
+    }
+
+    @Test
+    void loadStubsFromFile_failsWithClearMessageForUnknownMethod() throws IOException {
+        try (var server = Mokksy.create()) {
+            var yaml = """
+                    stubs:
+                      - name: bad-method
+                        method: BREW
+                        path: /coffee
+                        response:
+                          body: ok
+                    """;
+            Path file = Files.createTempFile("stubs", ".yaml");
+            Files.writeString(file, yaml);
+
+            try {
+                assertThatThrownBy(() -> server.loadStubsFromFile(file.toFile()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("BREW");
+            } finally {
+                Files.deleteIfExists(file);
+            }
+        }
+    }
+
+    @Test
+    void loadStubsFromFile_failsWithClearMessageForSseWithNoChunks() throws IOException {
+        var server = Mokksy.create();
+        var yaml = """
+                stubs:
+                  - name: empty-sse
+                    path: /sse
+                    response:
+                      type: sse
+                """;
+        Path file = Files.createTempFile("stubs", ".yaml");
+        Files.writeString(file, yaml);
+
+        try {
+            assertThatThrownBy(() -> server.loadStubsFromFile(file.toFile()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty-sse")
+                .hasMessageContaining("chunk");
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    // endregion
+
+    // region env / system property loading
+
+    @Test
+    void loadStubsFromEnv_readsPathFromSystemProperty() throws URISyntaxException {
+        Assumptions.assumeTrue(
+            System.getenv("MOKKSY_CONFIG") == null,
+            "MOKKSY_CONFIG env var is set — skipping"
+        );
+        var file = new File(requireNonNull(getClass().getResource("/it-stubs.yaml")).toURI());
+        System.setProperty("mokksy.config", file.getAbsolutePath());
+        try {
+            try (var server = Mokksy.create()) {
+                server.loadStubsFromEnv(); // should not throw
+            }
+        } finally {
+            System.clearProperty("mokksy.config");
+        }
+    }
+
+    @Test
+    void loadStubsFromEnv_throwsWhenNeitherEnvVarNorPropertyIsSet() {
+        Assumptions.assumeTrue(System.getenv("MOKKSY_CONFIG") == null, "MOKKSY_CONFIG env var is set — skipping");
+        System.clearProperty("mokksy.config");
+        try (var server = Mokksy.create()) {
+
+            assertThatThrownBy(server::loadStubsFromEnv)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("MOKKSY_CONFIG")
+                .hasMessageContaining("mokksy.config");
+        }
+    }
+
+    // endregion
+
+    // region helpers
+
+    private HttpResponse<String> get(String path) throws IOException, InterruptedException {
+        return httpClient.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(mokksy.baseUrl() + path))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+    }
+
+    private HttpResponse<String> post(String path, String body) throws IOException, InterruptedException {
+        return httpClient.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(mokksy.baseUrl() + path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+    }
+
+    // endregion
+}

--- a/integration-tests/src/jvmTest/resources/it-stubs.yaml
+++ b/integration-tests/src/jvmTest/resources/it-stubs.yaml
@@ -1,0 +1,49 @@
+stubs:
+  - name: ping
+    method: GET
+    path: /ping
+    response:
+      body: '{"response":"Pong"}'
+      status: 200
+
+  - name: create-thing
+    method: POST
+    path: /things
+    match:
+      bodyContains:
+        - '"42"'
+      headers:
+        Content-Type: application/json
+    response:
+      body: '{"id":"42","name":"thing-42"}'
+      status: 201
+      headers:
+        Location: /things/42
+        Foo: bar
+
+  - name: delayed-response
+    method: GET
+    path: /delayed
+    response:
+      body: ok
+      status: 200
+      delayMs: 100
+
+  - name: sse-events
+    method: POST
+    path: /sse
+    response:
+      type: sse
+      chunks:
+        - "One"
+        - "Two"
+
+  - name: text-stream
+    method: GET
+    path: /stream
+    response:
+      type: stream
+      chunks:
+        - "Hello"
+        - " World"
+      contentType: text/plain; charset=UTF-8

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -46,6 +46,9 @@ public final class dev/mokksy/Mokksy : java/lang/AutoCloseable {
 	public final fun head (Ljava/util/function/Consumer;)Ldev/mokksy/mokksy/JavaBuildingStep;
 	public final synthetic fun head (Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final synthetic fun head (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
+	public final fun loadStubsFromEnv ()Ldev/mokksy/Mokksy;
+	public final fun loadStubsFromFile (Ljava/io/File;)Ldev/mokksy/Mokksy;
+	public final fun loadStubsFromFile (Ljava/lang/String;)Ldev/mokksy/Mokksy;
 	public final fun method (Ldev/mokksy/mokksy/StubConfiguration;Ljava/lang/String;Ljava/lang/String;)Ldev/mokksy/mokksy/JavaBuildingStep;
 	public final fun method (Ldev/mokksy/mokksy/StubConfiguration;Ljava/lang/String;Ljava/util/function/Consumer;)Ldev/mokksy/mokksy/JavaBuildingStep;
 	public final fun method (Ljava/lang/String;Ljava/lang/String;)Ldev/mokksy/mokksy/JavaBuildingStep;
@@ -203,6 +206,14 @@ public final class dev/mokksy/mokksy/KtorExtensions {
 }
 
 public abstract interface annotation class dev/mokksy/mokksy/MokksyDsl : java/lang/annotation/Annotation {
+}
+
+public final class dev/mokksy/mokksy/MokksyFileConfigExtensionsKt {
+	public static final field ENV_MOKKSY_CONFIG Ljava/lang/String;
+	public static final field PROP_MOKKSY_CONFIG Ljava/lang/String;
+	public static final fun loadStubsFromEnv (Ldev/mokksy/mokksy/MokksyServer;)Ldev/mokksy/mokksy/MokksyServer;
+	public static final fun loadStubsFromFile (Ldev/mokksy/mokksy/MokksyServer;Ljava/io/File;)Ldev/mokksy/mokksy/MokksyServer;
+	public static final fun loadStubsFromFile (Ldev/mokksy/mokksy/MokksyServer;Ljava/lang/String;)Ldev/mokksy/mokksy/MokksyServer;
 }
 
 public abstract interface class dev/mokksy/mokksy/MokksyHandler {

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -67,6 +67,7 @@ kotlin {
             dependencies {
                 implementation(project.dependencies.platform(libs.netty.bom))
                 implementation(libs.jansi)
+                implementation(libs.kaml)
                 compileOnly(libs.ktor.serialization.jackson)
                 implementation(libs.ktor.server.call.logging)
                 implementation(libs.ktor.server.netty)

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
@@ -7,6 +7,8 @@ import dev.mokksy.mokksy.JavaBuildingStep
 import dev.mokksy.mokksy.JavaRequestSpecificationBuilder
 import dev.mokksy.mokksy.MokksyServer
 import dev.mokksy.mokksy.StubConfiguration
+import dev.mokksy.mokksy.loadStubsFromEnv
+import dev.mokksy.mokksy.loadStubsFromFile
 import dev.mokksy.mokksy.request.RecordedRequest
 import dev.mokksy.mokksy.request.RequestSpecification
 import dev.mokksy.mokksy.request.RequestSpecificationBuilder
@@ -19,6 +21,7 @@ import io.ktor.http.HttpMethod.Companion.Patch
 import io.ktor.http.HttpMethod.Companion.Post
 import io.ktor.http.HttpMethod.Companion.Put
 import kotlinx.coroutines.runBlocking
+import java.io.File
 import java.util.function.Consumer
 import kotlin.reflect.KClass
 
@@ -128,6 +131,47 @@ public class Mokksy(
      * Returns the port the server is bound to. Available after [start] has returned.
      */
     public fun port(): Int = delegate.port()
+
+    // endregion
+
+    // region File config
+
+    /**
+     * Loads stub definitions from the YAML [file] and registers them with this server.
+     *
+     * @param file YAML config file.
+     * @return This instance for chaining.
+     * @throws IllegalArgumentException if the file is missing, invalid, or fails validation.
+     */
+    public fun loadStubsFromFile(file: File): Mokksy {
+        delegate.loadStubsFromFile(file)
+        return this
+    }
+
+    /**
+     * Loads stub definitions from the YAML file at [path] and registers them with this server.
+     *
+     * @param path Absolute or relative path to the YAML config file.
+     * @return This instance for chaining.
+     * @throws IllegalArgumentException if the file is missing, invalid, or fails validation.
+     */
+    public fun loadStubsFromFile(path: String): Mokksy {
+        delegate.loadStubsFromFile(path)
+        return this
+    }
+
+    /**
+     * Loads stub definitions from the file specified by the `MOKKSY_CONFIG` environment variable
+     * or the `-Dmokksy.config` system property, in that order.
+     *
+     * @return This instance for chaining.
+     * @throws IllegalStateException if neither the environment variable nor the system property is set.
+     * @throws IllegalArgumentException if the resolved file is missing or invalid.
+     */
+    public fun loadStubsFromEnv(): Mokksy {
+        delegate.loadStubsFromEnv()
+        return this
+    }
 
     // endregion
 

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/MokksyFileConfigExtensions.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/MokksyFileConfigExtensions.kt
@@ -1,0 +1,116 @@
+package dev.mokksy.mokksy
+
+import dev.mokksy.mokksy.config.applyConfig
+import dev.mokksy.mokksy.config.parseYamlConfig
+import dev.mokksy.mokksy.config.validateConfig
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Environment variable that provides the path to a Mokksy YAML config file. */
+public const val ENV_MOKKSY_CONFIG: String = "MOKKSY_CONFIG"
+
+/** JVM system property that provides the path to a Mokksy YAML config file. */
+public const val PROP_MOKKSY_CONFIG: String = "mokksy.config"
+
+/**
+ * Loads stub definitions from a YAML file at [path] and registers them with this server.
+ *
+ * See [loadStubsFromFile] for the supported YAML format.
+ *
+ * @param path Absolute or relative path to the YAML config file.
+ * @return This server instance for chaining.
+ * @throws IllegalArgumentException if the file is missing, cannot be read, or contains invalid YAML.
+ */
+public fun MokksyServer.loadStubsFromFile(path: String): MokksyServer =
+    loadStubsFromFile(File(path))
+
+/**
+ * Loads stub definitions from a YAML [file] and registers them with this server.
+ *
+ * Example file:
+ * ```yaml
+ * stubs:
+ *   - name: ping
+ *     method: GET
+ *     path: /ping
+ *     response:
+ *       body: '{"response":"Pong"}'
+ *       status: 200
+ *
+ *   - name: events
+ *     method: POST
+ *     path: /sse
+ *     response:
+ *       type: sse
+ *       chunks:
+ *         - "One"
+ *         - "Two"
+ * ```
+ *
+ * Supported response types:
+ * - `plain` (default) — static body with optional status, headers, and delay
+ * - `sse` — server-sent events stream; `chunks` are required
+ * - `stream` — plain chunked stream; `chunks` are required
+ *
+ * @param file YAML config file.
+ * @return This server instance for chaining.
+ * @throws IllegalArgumentException if the file is missing, cannot be read, contains invalid YAML,
+ *   or fails semantic validation (unknown method, empty chunks, etc.).
+ */
+@Suppress("ThrowsCount")
+public fun MokksyServer.loadStubsFromFile(file: File): MokksyServer {
+    val text =
+        try {
+            file.readText()
+        } catch (e: FileNotFoundException) {
+            throw IllegalArgumentException("Mokksy config file not found: ${file.absolutePath}", e)
+        } catch (e: IOException) {
+            throw IllegalArgumentException(
+                "Cannot read Mokksy config file '${file.absolutePath}': ${e.message}",
+                e,
+            )
+        }
+    val config =
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            parseYamlConfig(text)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw IllegalArgumentException(
+                "Invalid YAML in Mokksy config file '${file.absolutePath}': ${e.message}",
+                e,
+            )
+        }
+    validateConfig(config)
+    applyConfig(config)
+    return this
+}
+
+/**
+ * Loads stub definitions from the YAML file specified by the [ENV_MOKKSY_CONFIG] environment
+ * variable or the [PROP_MOKKSY_CONFIG] system property, in that order.
+ *
+ * Example:
+ * ```
+ * MOKKSY_CONFIG=/app/stubs.yaml java -jar app.jar
+ * # or
+ * java -Dmokksy.config=/app/stubs.yaml -jar app.jar
+ * ```
+ *
+ * @return This server instance for chaining.
+ * @throws IllegalStateException if neither the environment variable nor the system property is set.
+ * @throws IllegalArgumentException if the resolved file is missing or invalid.
+ */
+public fun MokksyServer.loadStubsFromEnv(): MokksyServer {
+    val path =
+        System.getenv(ENV_MOKKSY_CONFIG)?.trim()?.takeIf { it.isNotEmpty() }
+            ?: System.getProperty(PROP_MOKKSY_CONFIG)?.trim()?.takeIf { it.isNotEmpty() }
+            ?: error(
+                "No config path found. Set the '$ENV_MOKKSY_CONFIG' environment variable " +
+                    "or the '-D$PROP_MOKKSY_CONFIG' system property.",
+            )
+    return loadStubsFromFile(path)
+}

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/config/MokksyFileConfig.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/config/MokksyFileConfig.kt
@@ -1,0 +1,50 @@
+package dev.mokksy.mokksy.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class MokksyFileConfig(
+    val stubs: List<StubConfig> = emptyList(),
+)
+
+@Serializable
+internal data class StubConfig(
+    val name: String? = null,
+    val method: String = "GET",
+    val path: String,
+    val match: MatchConfig = MatchConfig(),
+    val response: ResponseConfig,
+) {
+    val normalizedMethod: String get() = method.uppercase()
+}
+
+@Serializable
+internal data class MatchConfig(
+    val bodyContains: List<String> = emptyList(),
+    val headers: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+internal data class ResponseConfig(
+    val type: ResponseType = ResponseType.PLAIN,
+    val body: String? = null,
+    val status: Int = 200,
+    val headers: Map<String, String> = emptyMap(),
+    val delayMs: Long = 0,
+    val chunks: List<String> = emptyList(),
+    val delayBetweenChunksMs: Long = 0,
+    val contentType: String? = null,
+)
+
+@Serializable
+internal enum class ResponseType {
+    @SerialName("plain")
+    PLAIN,
+
+    @SerialName("sse")
+    SSE,
+
+    @SerialName("stream")
+    STREAM,
+}

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/config/StubConfigLoader.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/config/StubConfigLoader.kt
@@ -1,0 +1,82 @@
+package dev.mokksy.mokksy.config
+
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
+import dev.mokksy.mokksy.MokksyServer
+import dev.mokksy.mokksy.SseEvent
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlin.time.Duration.Companion.milliseconds
+
+private val VALID_METHODS = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
+
+internal fun parseYamlConfig(text: String): MokksyFileConfig =
+    Yaml(configuration = YamlConfiguration(strictMode = false))
+        .decodeFromString(MokksyFileConfig.serializer(), text)
+
+internal fun validateConfig(config: MokksyFileConfig) {
+    config.stubs.forEachIndexed { index, stub ->
+        val id = stub.name ?: "stubs[$index]"
+        require(stub.path.isNotBlank()) { "$id: 'path' must not be blank" }
+        require(stub.normalizedMethod in VALID_METHODS) {
+            "$id: unknown HTTP method '${stub.method}'. Valid methods: ${VALID_METHODS.joinToString()}"
+        }
+        when (stub.response.type) {
+            ResponseType.SSE, ResponseType.STREAM -> {
+                require(stub.response.chunks.isNotEmpty()) {
+                    "$id: response type '${stub.response.type.name.lowercase()}' requires at least one chunk"
+                }
+            }
+
+            ResponseType.PLAIN -> {
+                // noop
+            }
+        }
+    }
+}
+
+internal fun MokksyServer.applyConfig(config: MokksyFileConfig) {
+    config.stubs.forEach { stub -> registerFromConfig(stub) }
+}
+
+private fun MokksyServer.registerFromConfig(stub: StubConfig) {
+    val buildingStep =
+        method(
+            name = stub.name,
+            httpMethod = HttpMethod.parse(stub.normalizedMethod),
+            requestType = String::class,
+        ) {
+            path(stub.path)
+            stub.match.bodyContains.forEach { bodyContains(it) }
+            stub.match.headers.forEach { (name, value) -> containsHeader(name, value) }
+        }
+
+    when (stub.response.type) {
+        ResponseType.PLAIN -> {
+            buildingStep.respondsWith {
+                body = stub.response.body
+                httpStatus = HttpStatusCode.fromValue(stub.response.status)
+                stub.response.headers.forEach { (name, value) -> addHeader(name, value) }
+                delay = stub.response.delayMs.milliseconds
+            }
+        }
+
+        ResponseType.SSE -> {
+            buildingStep.respondsWithSseStream {
+                stub.response.chunks.forEach { chunk -> chunks += SseEvent.data(chunk) }
+                delayBetweenChunks = stub.response.delayBetweenChunksMs.milliseconds
+                delay = stub.response.delayMs.milliseconds
+            }
+        }
+
+        ResponseType.STREAM -> {
+            buildingStep.respondsWithStream {
+                stub.response.chunks.forEach { chunk -> chunks += chunk }
+                delayBetweenChunks = stub.response.delayBetweenChunksMs.milliseconds
+                delay = stub.response.delayMs.milliseconds
+                stub.response.contentType?.let { ct -> contentType = ContentType.parse(ct) }
+            }
+        }
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/config/MokksyFileConfigTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/config/MokksyFileConfigTest.kt
@@ -1,0 +1,275 @@
+package dev.mokksy.mokksy.config
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+internal class MokksyFileConfigTest {
+    // region parsing
+
+    @Test
+    fun `parses minimal plain stub`() {
+        // language=yaml
+        val yaml =
+            """
+            stubs:
+              - path: /ping
+                response:
+                  body: pong
+            """.trimIndent()
+
+        val config = parseYamlConfig(yaml)
+
+        config.stubs shouldHaveSize 1
+        val stub = config.stubs[0]
+        assertSoftly(stub) {
+            name shouldBe null
+            method shouldBe "GET"
+            path shouldBe "/ping"
+            response.type shouldBe ResponseType.PLAIN
+            response.body shouldBe "pong"
+            response.status shouldBe 200
+        }
+    }
+
+    @Test
+    fun `parses all plain response fields`() {
+        // language=yaml
+        val yaml =
+            """
+            stubs:
+              - name: create-thing
+                method: POST
+                path: /things
+                match:
+                  bodyContains:
+                    - '"42"'
+                  headers:
+                    Content-Type: application/json
+                response:
+                  body: '{"id":"42"}'
+                  status: 201
+                  headers:
+                    Location: /things/42
+                  delayMs: 100
+            """.trimIndent()
+
+        val config = parseYamlConfig(yaml)
+
+        config.stubs shouldHaveSize 1
+        val stub = config.stubs[0]
+        assertSoftly(stub) {
+            name shouldBe "create-thing"
+            method shouldBe "POST"
+            path shouldBe "/things"
+            match.bodyContains shouldBe listOf("\"42\"")
+            match.headers shouldBe mapOf("Content-Type" to "application/json")
+            response.type shouldBe ResponseType.PLAIN
+            response.body shouldBe """{"id":"42"}"""
+            response.status shouldBe 201
+            response.headers shouldBe mapOf("Location" to "/things/42")
+            response.delayMs shouldBe 100L
+        }
+    }
+
+    @Test
+    fun `parses SSE response`() {
+        // language=yaml
+        val yaml =
+            """
+            stubs:
+              - path: /sse
+                method: POST
+                response:
+                  type: sse
+                  chunks:
+                    - "One"
+                    - "Two"
+                  delayBetweenChunksMs: 50
+            """.trimIndent()
+
+        val config = parseYamlConfig(yaml)
+
+        val response = config.stubs[0].response
+        assertSoftly(response) {
+            type shouldBe ResponseType.SSE
+            chunks shouldBe listOf("One", "Two")
+            delayBetweenChunksMs shouldBe 50L
+        }
+    }
+
+    @Test
+    fun `parses stream response`() {
+        // language=yaml
+        val yaml =
+            """
+            stubs:
+              - path: /stream
+                response:
+                  type: stream
+                  chunks:
+                    - "Hello"
+                    - " World"
+                  contentType: text/plain; charset=UTF-8
+            """.trimIndent()
+
+        val config = parseYamlConfig(yaml)
+
+        val response = config.stubs[0].response
+        assertSoftly(response) {
+            type shouldBe ResponseType.STREAM
+            chunks shouldBe listOf("Hello", " World")
+            contentType shouldBe "text/plain; charset=UTF-8"
+        }
+    }
+
+    @Test
+    fun `parses multiple stubs`() {
+        // language=yaml
+        val yaml =
+            """
+            stubs:
+              - path: /a
+                response:
+                  body: a
+              - path: /b
+                method: POST
+                response:
+                  body: b
+            """.trimIndent()
+
+        val config = parseYamlConfig(yaml)
+
+        config.stubs shouldHaveSize 2
+        config.stubs[0].path shouldBe "/a"
+        config.stubs[1].path shouldBe "/b"
+    }
+
+    @Test
+    fun `parses empty stubs list`() {
+        // language=yaml
+        val yaml = "stubs: []"
+
+        val config = parseYamlConfig(yaml)
+
+        config.stubs shouldHaveSize 0
+    }
+
+    // endregion
+
+    // region validation
+
+    @Test
+    fun `validation passes for valid config`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(
+                            path = "/ping",
+                            method = "GET",
+                            response = ResponseConfig(body = "ok"),
+                        ),
+                    ),
+            )
+
+        validateConfig(config) // should not throw
+    }
+
+    @Test
+    fun `validation fails for blank path`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(
+                            name = "blank-path",
+                            path = "  ",
+                            response = ResponseConfig(),
+                        ),
+                    ),
+            )
+
+        val ex = shouldThrow<IllegalArgumentException> { validateConfig(config) }
+        ex.message shouldContain "blank-path"
+        ex.message shouldContain "path"
+    }
+
+    @Test
+    fun `validation fails for unknown HTTP method`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(
+                            path = "/x",
+                            method = "BREW",
+                            response = ResponseConfig(),
+                        ),
+                    ),
+            )
+
+        val ex = shouldThrow<IllegalArgumentException> { validateConfig(config) }
+        ex.message shouldContain "BREW"
+    }
+
+    @Test
+    fun `validation fails for SSE response with no chunks`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(
+                            name = "empty-sse",
+                            path = "/sse",
+                            response = ResponseConfig(type = ResponseType.SSE),
+                        ),
+                    ),
+            )
+
+        val ex = shouldThrow<IllegalArgumentException> { validateConfig(config) }
+        ex.message shouldContain "empty-sse"
+        ex.message shouldContain "sse"
+        ex.message shouldContain "chunk"
+    }
+
+    @Test
+    fun `validation fails for stream response with no chunks`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(
+                            name = "empty-stream",
+                            path = "/stream",
+                            response = ResponseConfig(type = ResponseType.STREAM),
+                        ),
+                    ),
+            )
+
+        val ex = shouldThrow<IllegalArgumentException> { validateConfig(config) }
+        ex.message shouldContain "empty-stream"
+        ex.message shouldContain "stream"
+        ex.message shouldContain "chunk"
+    }
+
+    @Test
+    fun `validation error includes stub index when name is absent`() {
+        val config =
+            MokksyFileConfig(
+                stubs =
+                    listOf(
+                        StubConfig(path = "/ok", response = ResponseConfig()),
+                        StubConfig(path = "/ok2", method = "BREW", response = ResponseConfig()),
+                    ),
+            )
+
+        val ex = shouldThrow<IllegalArgumentException> { validateConfig(config) }
+        ex.message shouldContain "stubs[1]"
+    }
+
+    // endregion
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/config/StubFileConfigIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/config/StubFileConfigIT.kt
@@ -1,0 +1,248 @@
+package dev.mokksy.mokksy.config
+
+import dev.mokksy.mokksy.ENV_MOKKSY_CONFIG
+import dev.mokksy.mokksy.MokksyServer
+import dev.mokksy.mokksy.PROP_MOKKSY_CONFIG
+import dev.mokksy.mokksy.createKtorSSEClient
+import dev.mokksy.mokksy.loadStubsFromEnv
+import dev.mokksy.mokksy.loadStubsFromFile
+import dev.mokksy.mokksy.shutdown
+import dev.mokksy.mokksy.start
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.withCharset
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.File
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.writeText
+import kotlin.text.Charsets.UTF_8
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class StubFileConfigIT {
+    private val mokksy = MokksyServer(verbose = true)
+    private lateinit var client: HttpClient
+
+    @BeforeAll
+    fun setup() {
+        val file = javaClass.getResource("/test-stubs.yaml")!!.file
+        mokksy.start()
+        mokksy.loadStubsFromFile(file)
+        client = createKtorSSEClient(mokksy.port())
+    }
+
+    @AfterAll
+    fun teardown() {
+        mokksy.shutdown()
+        client.close()
+    }
+
+    // region plain responses
+
+    @Test
+    suspend fun `GET stub returns plain response from file config`() {
+        val result = client.get("/ping")
+
+        assertSoftly(result) {
+            status shouldBe HttpStatusCode.OK
+            bodyAsText() shouldBe """{"response":"Pong"}"""
+        }
+    }
+
+    @Test
+    suspend fun `POST stub with body match returns configured status and headers`() {
+        val result =
+            client.post("/things") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody("""{"id":"42"}""")
+            }
+
+        assertSoftly(result) {
+            status shouldBe HttpStatusCode.Created
+            bodyAsText() shouldBe """{"id":"42","name":"thing-42"}"""
+            headers["Location"] shouldBe "/things/42"
+            headers["Foo"] shouldBe "bar"
+        }
+    }
+
+    @Test
+    suspend fun `POST stub does not match when body does not contain expected string`() {
+        val result =
+            client.post("/things") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody("""{"id":"99"}""")
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+    }
+
+    @Test
+    suspend fun `GET delayed stub returns response after delay`() {
+        val result = client.get("/delayed")
+
+        assertSoftly(result) {
+            status shouldBe HttpStatusCode.OK
+            bodyAsText() shouldBe "ok"
+        }
+    }
+
+    // endregion
+
+    // region SSE stream
+
+    @Test
+    suspend fun `POST stub returns SSE stream from file config`() {
+        val result = client.post("/sse")
+
+        assertSoftly(result) {
+            status shouldBe HttpStatusCode.OK
+            contentType() shouldBe ContentType.Text.EventStream.withCharset(UTF_8)
+            bodyAsText() shouldBe "data: One\r\n\r\ndata: Two\r\n\r\n"
+        }
+    }
+
+    // endregion
+
+    // region plain text stream
+
+    @Test
+    suspend fun `GET stub returns plain text stream from file config`() {
+        val result = client.get("/stream")
+
+        assertSoftly(result) {
+            status shouldBe HttpStatusCode.OK
+            contentType() shouldBe ContentType.Text.Plain.withCharset(UTF_8)
+            bodyAsText() shouldBe "Hello World"
+        }
+    }
+
+    // endregion
+
+    // region error cases (use a fresh server, no need to start it for parse errors)
+
+    @Test
+    fun `loadStubsFromFile fails with clear message when file is missing`() {
+        val server = MokksyServer()
+        val missing = File("/nonexistent/path/stubs.yaml")
+
+        val ex = shouldThrow<IllegalArgumentException> { server.loadStubsFromFile(missing) }
+        ex.message shouldContain "not found"
+        ex.message shouldContain missing.absolutePath
+    }
+
+    @Test
+    fun `loadStubsFromFile fails with clear message for invalid YAML`() {
+        val server = MokksyServer()
+        val badYaml = createTempFile("bad", ".yaml")
+        badYaml.writeText("stubs: [{ path: /x, response: { status: not-a-number } }]")
+
+        try {
+            val ex =
+                shouldThrow<IllegalArgumentException> { server.loadStubsFromFile(badYaml.toFile()) }
+            ex.message shouldContain "Invalid YAML"
+        } finally {
+            badYaml.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `loadStubsFromFile fails with clear message for unknown HTTP method`() {
+        val server = MokksyServer()
+        val yaml =
+            """
+            stubs:
+              - name: bad-method
+                method: BREW
+                path: /coffee
+                response:
+                  body: ok
+            """.trimIndent()
+        val file = createTempFile("stubs", ".yaml")
+        file.writeText(yaml)
+
+        try {
+            val ex =
+                shouldThrow<IllegalArgumentException> { server.loadStubsFromFile(file.toFile()) }
+            ex.message shouldContain "BREW"
+        } finally {
+            file.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `loadStubsFromFile fails with clear message for SSE with no chunks`() {
+        val server = MokksyServer()
+        val yaml =
+            """
+            stubs:
+              - name: empty-sse
+                path: /sse
+                response:
+                  type: sse
+            """.trimIndent()
+        val file = createTempFile("stubs", ".yaml")
+        file.writeText(yaml)
+
+        try {
+            val ex =
+                shouldThrow<IllegalArgumentException> { server.loadStubsFromFile(file.toFile()) }
+            ex.message shouldContain "empty-sse"
+            ex.message shouldContain "chunk"
+        } finally {
+            file.deleteIfExists()
+        }
+    }
+
+    // endregion
+
+    // region env / system property loading
+
+    @Test
+    fun `loadStubsFromEnv reads path from system property`() {
+        assumeTrue(
+            System.getenv(ENV_MOKKSY_CONFIG) == null,
+            "MOKKSY_CONFIG env var is set — skipping",
+        )
+        val file = File(javaClass.getResource("/test-stubs.yaml")!!.toURI())
+        System.setProperty(PROP_MOKKSY_CONFIG, file.absolutePath)
+        try {
+            val server = MokksyServer()
+            server.loadStubsFromEnv() // should not throw
+        } finally {
+            System.clearProperty(PROP_MOKKSY_CONFIG)
+        }
+    }
+
+    @Test
+    fun `loadStubsFromEnv throws when neither env var nor property is set`() {
+        Assumptions.assumeTrue(
+            System.getenv(ENV_MOKKSY_CONFIG) == null,
+            "MOKKSY_CONFIG env var is set — skipping",
+        )
+        System.clearProperty(PROP_MOKKSY_CONFIG)
+        val server = MokksyServer()
+
+        val ex = shouldThrow<IllegalStateException> { server.loadStubsFromEnv() }
+        ex.message shouldContain ENV_MOKKSY_CONFIG
+        ex.message shouldContain PROP_MOKKSY_CONFIG
+    }
+
+    // endregion
+}

--- a/mokksy/src/jvmTest/resources/test-stubs.yaml
+++ b/mokksy/src/jvmTest/resources/test-stubs.yaml
@@ -1,0 +1,49 @@
+stubs:
+  - name: ping
+    method: GET
+    path: /ping
+    response:
+      body: '{"response":"Pong"}'
+      status: 200
+
+  - name: create-thing
+    method: POST
+    path: /things
+    match:
+      bodyContains:
+        - '"42"'
+      headers:
+        Content-Type: application/json
+    response:
+      body: '{"id":"42","name":"thing-42"}'
+      status: 201
+      headers:
+        Location: /things/42
+        Foo: bar
+
+  - name: delayed-response
+    method: GET
+    path: /delayed
+    response:
+      body: ok
+      status: 200
+      delayMs: 100
+
+  - name: sse-events
+    method: POST
+    path: /sse
+    response:
+      type: sse
+      chunks:
+        - "One"
+        - "Two"
+
+  - name: text-stream
+    method: GET
+    path: /stream
+    response:
+      type: stream
+      chunks:
+        - "Hello"
+        - " World"
+      contentType: text/plain; charset=UTF-8


### PR DESCRIPTION
## Add file-based YAML configuration for mock stubs (#122) 

 - Support loading stubs from YAML files via `loadStubsFromFile(File|String)`
  - Support loading from environment variable `MOKKSY_CONFIG` or system property `-Dmokksy.config` via `loadStubsFromEnv()`
  - Add public methods to `Mokksy` Java facade for file-based config
  - Support all response types: plain, SSE streams, and plain text streams
  - Validate config at load time with clear error messages for missing files, invalid YAML, unknown HTTP methods, and empty chunks
  - Add unit tests for parsing and validation
  - Add integration tests for all response types and error cases (Kotlin and Java)