### PR TITLE
fix: gradlew clean and run docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,17 +6,54 @@ on:
       - created
   push:
     branches: [ "main" ]
-  # Allow running this workflow manually from the Actions tab
+
+  pull_request:
+    branches: [ "main" ]
+
   workflow_dispatch:
 
 env:
   JVM_VERSION: 25
   JVM_DISTRIBUTION: temurin
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
-  deploy:
+
+  verify-docs:
+    if: ${{ github.ref != 'refs/heads/main' }}
+    runs-on: ubuntu-latest
 
     permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Set up JDK ${{ env.JVM_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JVM_VERSION }}
+          distribution: ${{ env.JVM_DISTRIBUTION }}
+
+      - name: 🐘Setup Gradle
+        uses: gradle/actions/setup-gradle@11d4d83c63a6ce61b32d8a9c4faddbdb04fe9917 # v6.1.0
+        with:
+          cache-provider: basic
+
+      - name: Generate Dokka Site
+        run: |-
+          make knit apidocs
+
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
 
@@ -36,21 +73,21 @@ jobs:
         with:
           java-version: ${{ env.JVM_VERSION }}
           distribution: ${{ env.JVM_DISTRIBUTION }}
-          cache: gradle
 
       - name: 🐘Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@11d4d83c63a6ce61b32d8a9c4faddbdb04fe9917 # v6.1.0
+        with:
+          cache-provider: basic
 
       - name: Generate Dokka Site
         run: |-
-          ./gradlew clean
-          make knit
-          ./gradlew dokkaGenerate
+          make knit apidocs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: mokksy/build/dokka/html
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Set up JDK ${{ env.JVM_VERSION }}
         uses: actions/setup-java@v5
         with:
-          cache: gradle
           java-version: ${{ env.JVM_VERSION }}
           distribution: ${{ env.JVM_DISTRIBUTION }}
 
@@ -50,7 +49,7 @@ jobs:
       - name: 🐘Setup Gradle
         uses: gradle/actions/setup-gradle@11d4d83c63a6ce61b32d8a9c4faddbdb04fe9917
         with:
-          cache-disabled: true
+          cache-provider: basic
           add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
 
       - name: Build with Gradle
@@ -93,8 +92,8 @@ jobs:
           report_type: test_results
 
   dependency-submission:
-
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
 
@@ -110,3 +109,5 @@ jobs:
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@11d4d83c63a6ce61b32d8a9c4faddbdb04fe9917
+        with:
+          cache-provider: basic

--- a/buildSrc/src/main/kotlin/docker-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/docker-convention.gradle.kts
@@ -1,5 +1,6 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+import com.github.dockerjava.api.exception.NotFoundException
 
 plugins {
     id("com.bmuschko.docker-remote-api")
@@ -70,8 +71,11 @@ afterEvaluate {
         group = "docker"
         targetImageId(dockerImageName)
         onError {
-            // Image not present locally — nothing to remove, not an error.
-            if (!message.orEmpty().contains("image not known")) throw this
+            if (this is NotFoundException) {
+                // Image not present locally — nothing to remove, not an error.
+            } else {
+                throw this
+            }
         }
     }
 


### PR DESCRIPTION
Updates CI workflows and Docker Gradle script: expands and splits docs workflow into verify/deploy paths, enables basic Gradle cache and narrows dependency-submission to same-repo PRs, and changes Docker image-removal handling to detect missing images by exception type.