### PR TITLE
feat: extract isJsonContentType, add registerJsonContentType and Java…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@
 - Use unit tests only for edge cases where integration tests are hard to write
 - Never mock Ktor request/response types — use `testApplication` instead
 - Test new and modified code
+- Do not write redundant and tautological tests.
+- Prefer adding more soft assertions to integration tests, not more tests verifying same scenario over and over.
 - Use AssertJ for testing in Java code.
 - Use Kotest assertions
 - Use JUnit6 `@Test` annotations with suspend functions in JVM tests.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4G"
 org.gradle.parallel=true
 
-version=0.10.0
+version=0.10.1-SNAPSHOT
 
 dockerImageName=mokksy/server-jvm
 dockerImageTag=snapshot

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -1001,10 +1001,15 @@ public final class dev/mokksy/mokksy/utils/highlight/ColorTheme : java/lang/Enum
 
 public final class dev/mokksy/mokksy/utils/highlight/Highlighting {
 	public static final field INSTANCE Ldev/mokksy/mokksy/utils/highlight/Highlighting;
-	public final fun highlightBody (Ljava/lang/String;Lio/ktor/http/ContentType;Z)Ljava/lang/String;
-	public final fun highlightBody (Lkotlinx/serialization/json/JsonElement;Z)Ljava/lang/String;
-	public static synthetic fun highlightBody$default (Ldev/mokksy/mokksy/utils/highlight/Highlighting;Ljava/lang/String;Lio/ktor/http/ContentType;ZILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun highlightBody$default (Ldev/mokksy/mokksy/utils/highlight/Highlighting;Lkotlinx/serialization/json/JsonElement;ZILjava/lang/Object;)Ljava/lang/String;
+	public static final synthetic fun highlightBody (Ljava/lang/String;Lio/ktor/http/ContentType;Z)Ljava/lang/String;
+	public static final fun highlightBody (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun highlightBody (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static final synthetic fun highlightBody (Lkotlinx/serialization/json/JsonElement;Z)Ljava/lang/String;
+	public static synthetic fun highlightBody$default (Ljava/lang/String;Lio/ktor/http/ContentType;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun highlightBody$default (Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun highlightBody$default (Lkotlinx/serialization/json/JsonElement;ZILjava/lang/Object;)Ljava/lang/String;
+	public static final synthetic fun registerJsonContentType (Lio/ktor/http/ContentType;)V
+	public static final fun registerJsonContentType (Ljava/lang/String;)V
 }
 
 public class dev/mokksy/mokksy/utils/logger/HttpFormatter {

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -792,7 +792,10 @@ final object dev.mokksy.mokksy.jsonrpc/RequestIdSerializer : kotlinx.serializati
 
 final object dev.mokksy.mokksy.utils.highlight/Highlighting { // dev.mokksy.mokksy.utils.highlight/Highlighting|null[0]
     final fun highlightBody(kotlin/String, io.ktor.http/ContentType, kotlin/Boolean = ...): kotlin/String // dev.mokksy.mokksy.utils.highlight/Highlighting.highlightBody|highlightBody(kotlin.String;io.ktor.http.ContentType;kotlin.Boolean){}[0]
+    final fun highlightBody(kotlin/String, kotlin/String, kotlin/Boolean = ...): kotlin/String // dev.mokksy.mokksy.utils.highlight/Highlighting.highlightBody|highlightBody(kotlin.String;kotlin.String;kotlin.Boolean){}[0]
     final fun highlightBody(kotlinx.serialization.json/JsonElement, kotlin/Boolean = ...): kotlin/String // dev.mokksy.mokksy.utils.highlight/Highlighting.highlightBody|highlightBody(kotlinx.serialization.json.JsonElement;kotlin.Boolean){}[0]
+    final fun registerJsonContentType(io.ktor.http/ContentType) // dev.mokksy.mokksy.utils.highlight/Highlighting.registerJsonContentType|registerJsonContentType(io.ktor.http.ContentType){}[0]
+    final fun registerJsonContentType(kotlin/String) // dev.mokksy.mokksy.utils.highlight/Highlighting.registerJsonContentType|registerJsonContentType(kotlin.String){}[0]
 }
 
 final const val dev.mokksy.mokksy.request/DEFAULT_STUB_PRIORITY // dev.mokksy.mokksy.request/DEFAULT_STUB_PRIORITY|{}DEFAULT_STUB_PRIORITY[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/FormParamsHighlighter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/FormParamsHighlighter.kt
@@ -9,7 +9,7 @@ internal object FormParamsHighlighter {
      * Applies ANSI color highlighting to URL-encoded form data.
      *
      * Splits the input string into key-value pairs separated by '&' and colors keys in yellow and values in green.
-     * Pairs that do not contain exactly one '=' are left unchanged.
+     * Pairs that do not contain a '=' are left unchanged.
      *
      * @param data The URL-encoded form data to highlight.
      * @param useColor Set explicitly should colorize or not
@@ -18,15 +18,38 @@ internal object FormParamsHighlighter {
     internal fun highlight(
         data: String,
         useColor: Boolean = isColorSupported(),
-    ): String =
-        data.split('&').joinToString("&") {
-            val parts = it.split('=', limit = 2)
-            if (parts.size == 2) {
-                val key = parts[0].colorize(AnsiColor.YELLOW, enabled = useColor)
-                val value = parts[1].colorize(AnsiColor.GREEN, enabled = useColor)
-                "$key=$value"
+    ): String = buildString {
+        var start = 0
+        while (start < data.length) {
+            if (start > 0) append('&')
+            val amp = data.indexOf('&', startIndex = start)
+            val pairEnd = if (amp == -1) data.length else amp
+            val eq = data.indexOf('=', startIndex = start).let { if (it == -1 || it >= pairEnd) -1 else it }
+            if (eq == -1) {
+                append(data, start, pairEnd)
             } else {
-                it
+                appendColorized(data, start, eq, AnsiColor.YELLOW, useColor)
+                append('=')
+                appendColorized(data, eq + 1, pairEnd, AnsiColor.GREEN, useColor)
             }
+            start = pairEnd + 1
         }
+    }
+
+    private fun StringBuilder.appendColorized(
+        data: String,
+        startIndex: Int,
+        endIndex: Int,
+        color: AnsiColor,
+        useColor: Boolean,
+    ) {
+        if (useColor) {
+            append(AnsiColor.RESET.code)
+            append(color.code)
+            append(data, startIndex, endIndex)
+            append(AnsiColor.RESET.code)
+        } else {
+            append(data, startIndex, endIndex)
+        }
+    }
 }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
@@ -24,7 +24,9 @@ public object Highlighting {
     /**
      * Registers a custom content type to be treated as JSON for highlighting purposes.
      *
-     * @param contentType The content type to register, e.g. `ContentType("application/x-ndjson")`.
+     * Example: `registerJsonContentType(ContentType("application/x-ndjson"))`
+     *
+     * @param contentType The content type to register.
      */
     @InternalMokksyApi
     @JvmStatic
@@ -37,6 +39,8 @@ public object Highlighting {
      * Registers a custom content type (given as a string) to be treated as JSON.
      *
      * Java-friendly overload of [registerJsonContentType].
+     *
+     * Example: `registerJsonContentType("application/x-ndjson")`
      */
     @InternalMokksyApi
     @JvmStatic
@@ -99,6 +103,8 @@ public object Highlighting {
      * Applies ANSI color highlighting to an HTTP body string for a content type given as a string.
      *
      * Java-friendly overload of [highlightBody] that accepts a content type string.
+     *
+     * Example: `highlightBody(body, "application/x-ndjson")`
      */
     @JvmStatic
     @JvmOverloads

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/Highlighting.kt
@@ -3,11 +3,47 @@
 package dev.mokksy.mokksy.utils.highlight
 
 import dev.mokksy.mokksy.InternalMokksyApi
+import dev.mokksy.mokksy.utils.highlight.Highlighting.highlightBody
+import dev.mokksy.mokksy.utils.highlight.Highlighting.registerJsonContentType
 import io.ktor.http.ContentType
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.serialization.json.JsonElement
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.update
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 @InternalMokksyApi
+@OptIn(ExperimentalAtomicApi::class)
 public object Highlighting {
+    private val additionalJsonContentTypes: AtomicReference<Set<ContentType>> =
+        AtomicReference(persistentSetOf())
+
+    /**
+     * Registers a custom content type to be treated as JSON for highlighting purposes.
+     *
+     * @param contentType The content type to register, e.g. `ContentType("application/x-ndjson")`.
+     */
+    @InternalMokksyApi
+    @JvmStatic
+    @JvmSynthetic
+    public fun registerJsonContentType(contentType: ContentType) {
+        additionalJsonContentTypes.update { it + contentType }
+    }
+
+    /**
+     * Registers a custom content type (given as a string) to be treated as JSON.
+     *
+     * Java-friendly overload of [registerJsonContentType].
+     */
+    @InternalMokksyApi
+    @JvmStatic
+    public fun registerJsonContentType(contentType: String) {
+        registerJsonContentType(ContentType.parse(contentType))
+    }
+
     /**
      * Applies ANSI color highlighting to an HTTP body string based on its content type.
      *
@@ -15,14 +51,15 @@ public object Highlighting {
      * @param contentType The content type of the body.
      * @return The highlighted body string with ANSI color codes.
      */
+    @JvmStatic
+    @JvmSynthetic
     public fun highlightBody(
         body: String,
         contentType: ContentType,
         useColor: Boolean = isColorSupported(),
     ): String =
         when {
-            contentType.match(ContentType.Application.Json) ||
-                contentType.contentSubtype.endsWith("+json", ignoreCase = true) -> {
+            isJsonContentType(contentType) -> {
                 JsonStringHighlighter.highlight(
                     json = body,
                     useColor = useColor,
@@ -51,10 +88,38 @@ public object Highlighting {
      * @param useColor Whether to apply ANSI color codes.
      * @return The highlighted JSON string.
      */
+    @JvmStatic
+    @JvmSynthetic
     public fun highlightBody(
         body: JsonElement,
         useColor: Boolean = isColorSupported(),
     ): String = JsonElementHighlighter.highlight(body, useColor)
+
+    /**
+     * Applies ANSI color highlighting to an HTTP body string for a content type given as a string.
+     *
+     * Java-friendly overload of [highlightBody] that accepts a content type string.
+     */
+    @JvmStatic
+    @JvmOverloads
+    public fun highlightBody(
+        body: String,
+        contentType: String,
+        useColor: Boolean = isColorSupported(),
+    ): String = highlightBody(body, ContentType.parse(contentType), useColor)
+
+    /**
+     * Determines whether the given [contentType] should be highlighted as JSON.
+     *
+     * Returns `true` for `application/json`, any `+json` subtype,
+     * and any content type registered via [registerJsonContentType].
+     */
+    @JvmStatic
+    @JvmSynthetic
+    internal fun isJsonContentType(contentType: ContentType): Boolean =
+        contentType.match(ContentType.Application.Json) ||
+            contentType.contentSubtype.endsWith("+json", ignoreCase = true) ||
+            contentType in additionalJsonContentTypes.load()
 }
 
 @InternalMokksyApi
@@ -97,4 +162,5 @@ public enum class AnsiColor(
 internal fun String.colorize(
     color: AnsiColor,
     enabled: Boolean = isColorSupported(),
-): String = if (enabled) "${AnsiColor.RESET.code}${color.code}$this${AnsiColor.RESET.code}" else this
+): String =
+    if (enabled) "${AnsiColor.RESET.code}${color.code}$this${AnsiColor.RESET.code}" else this

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/highlight/JsonElementHighlighter.kt
@@ -46,14 +46,16 @@ internal object JsonElementHighlighter {
         depth: Int,
     ) {
         append('{')
-        val entries = obj.entries.toList()
-        entries.forEachIndexed { i, (key, value) ->
+        val entries = obj.entries
+        var i = 0
+        for ((key, value) in entries) {
             appendLine()
             indent(depth + 1)
             appendKey(key, useColor)
             append(": ")
             appendElement(value, useColor, depth + 1)
             if (i < entries.size - 1) append(',')
+            i++
         }
         if (entries.isNotEmpty()) {
             appendLine()

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
@@ -236,11 +236,14 @@ public open class HttpFormatter(
 
     @OptIn(InternalSerializationApi::class)
     @Suppress("UNCHECKED_CAST")
-    private fun tryEncodeToJsonElement(body: Any): JsonElement? =
-        runCatching {
-            val serializer = body::class.serializerOrNull() ?: return null
+    private fun tryEncodeToJsonElement(body: Any): JsonElement? {
+        val serializer = body::class.serializerOrNull() ?: return null
+        return try {
             json.encodeToJsonElement(serializer as KSerializer<Any>, body)
-        }.getOrNull()
+        } catch (_: Exception) {
+            null
+        }
+    }
 
     private fun ContentType.isTextContent(): Boolean =
         isJsonContentType(this) ||

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
@@ -148,19 +148,14 @@ public open class HttpFormatter(
         body: Any?,
         contentType: ContentType = ContentType.Any,
     ): String {
-        if (!contentType.isTextContent()) {
-            return "[binary content omitted]"
+        if (body == null) {
+            return ""
+        }
+        if (body is String && body.isBlank()) {
+            return ""
         }
 
         return when (body) {
-            null -> {
-                ""
-            }
-
-            is String if body.isBlank() -> {
-                ""
-            }
-
             is String -> {
                 if (useColor) highlightBody(body, contentType) else body
             }
@@ -170,8 +165,12 @@ public open class HttpFormatter(
             }
 
             else -> {
-                val jsonElement =
-                    if (isJsonContentType(contentType)) tryEncodeToJsonElement(body) else null
+                val isJson = isJsonContentType(contentType)
+
+                if (!isJson && !contentType.isTextContent()) {
+                    return "[binary content omitted]"
+                }
+                val jsonElement = if (isJson) tryEncodeToJsonElement(body) else null
                 jsonElement?.let { highlightBody(it, useColor) } ?: body.toString()
             }
         }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
@@ -6,6 +6,7 @@ import dev.mokksy.mokksy.InternalMokksyApi
 import dev.mokksy.mokksy.utils.highlight.AnsiColor
 import dev.mokksy.mokksy.utils.highlight.ColorTheme
 import dev.mokksy.mokksy.utils.highlight.Highlighting.highlightBody
+import dev.mokksy.mokksy.utils.highlight.Highlighting.isJsonContentType
 import dev.mokksy.mokksy.utils.highlight.colorize
 import dev.mokksy.mokksy.utils.highlight.isColorSupported
 import io.ktor.http.ContentType
@@ -169,13 +170,8 @@ public open class HttpFormatter(
             }
 
             else -> {
-                val isJson =
-                    contentType.match(ContentType.Application.Json) ||
-                        contentType.contentSubtype.endsWith(
-                            "+json",
-                            ignoreCase = true,
-                        )
-                val jsonElement = if (isJson) tryEncodeToJsonElement(body) else null
+                val jsonElement =
+                    if (isJsonContentType(contentType)) tryEncodeToJsonElement(body) else null
                 jsonElement?.let { highlightBody(it, useColor) } ?: body.toString()
             }
         }
@@ -247,11 +243,10 @@ public open class HttpFormatter(
         }.getOrNull()
 
     private fun ContentType.isTextContent(): Boolean =
-        match(ContentType.Application.Json) ||
+        isJsonContentType(this) ||
             match(ContentType.Application.Xml) ||
             match(ContentType.Application.FormUrlEncoded) ||
             match(ContentType.Text.Any) ||
-            contentSubtype.endsWith("+json", ignoreCase = true) ||
             contentSubtype.endsWith("+xml", ignoreCase = true)
 
     @InternalMokksyApi

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/highlight/HighlightingTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/highlight/HighlightingTest.kt
@@ -87,6 +87,34 @@ internal class HighlightingTest {
         }
     }
 
+    @Test
+    fun `should toggle JSON highlighting for registered custom content type`() {
+        val custom = ContentType("application", "x-ndjson")
+        val json = """{"key": "value"}"""
+
+        assertSoftly {
+            Highlighting.isJsonContentType(custom) shouldBe false
+
+            val before = Highlighting.highlightBody(
+                body = json,
+                contentType = custom,
+                useColor = true,
+            )
+            before shouldContain colorize(json, AnsiColor.LIGHT_GRAY)
+
+            Highlighting.registerJsonContentType(custom)
+            Highlighting.isJsonContentType(custom) shouldBe true
+
+            val after = Highlighting.highlightBody(
+                body = json,
+                contentType = custom,
+                useColor = true,
+            )
+            after shouldContain colorize("\"key\"", AnsiColor.MAGENTA)
+            after shouldContain colorize("\"value\"", AnsiColor.GREEN)
+        }
+    }
+
     private fun colorize(
         text: String,
         color: AnsiColor,

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatterTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatterTest.kt
@@ -3,7 +3,10 @@
 package dev.mokksy.mokksy.utils.logger
 
 import dev.mokksy.mokksy.InternalMokksyApi
+import dev.mokksy.mokksy.utils.highlight.Highlighting.isJsonContentType
+import dev.mokksy.mokksy.utils.highlight.Highlighting.registerJsonContentType
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.http.ContentType
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -81,5 +84,21 @@ internal class HttpFormatterTest {
         val dto = ContextualDto("world")
         val result = formatter.formatBody(dto, ContentType.Text.Plain)
         result shouldContain dto.toString()
+    }
+
+    @Test
+    fun `formatBody encodes typed body to JSON for registered custom content type`() {
+        val custom = ContentType("application", "x-ndjson-http-formatter")
+        registerJsonContentType(custom)
+        isJsonContentType(custom) shouldBe true
+
+        val formatter = HttpFormatter(useColor = false)
+        val result = formatter.formatBody(SimpleDto("Bob", 42), custom)
+        assertSoftly(result) {
+            this shouldContain "\"name\""
+            this shouldContain "\"Bob\""
+            this shouldContain "\"age\""
+            this shouldContain "42"
+        }
     }
 }


### PR DESCRIPTION
feat: extract isJsonContentType, add registerJsonContentType and Java String overloads

- Extract JSON content type detection into isJsonContentType function
- Add registerJsonContentType to allow arbitrary content types (e.g. application/x-ndjson) to be treated as JSON
- Thread-safe via kotlinx.atomicfu.AtomicReference
- Add @JvmStatic String-based overloads for Java API compatibility
- Add integration test verifying before/after registration behavior