### PR TITLE
Add onResponseReady/RequestListener callback to MokksyServer (#153)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,9 +7,6 @@ codecov:
 coverage:
   precision: 2
   round: down
-coverage:
-  precision: 2
-  round: down
   range: "80...100"
   status:
     project:
@@ -19,15 +16,6 @@ coverage:
     patch:
       default:
         target: 80%
-        threshold: 1%
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-    patch:
-      default:
-        target: auto
         threshold: 1%
 
 comment:

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -11,6 +11,7 @@ public final class dev/mokksy/Mokksy : java/lang/AutoCloseable {
 	public fun <init> (Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/String;IZ)V
 	public synthetic fun <init> (Ljava/lang/String;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addListener (Ldev/mokksy/mokksy/RequestListener;)V
 	public final fun allStubs ()Ljava/util/List;
 	public final synthetic fun awaitStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun baseUrl ()Ljava/lang/String;
@@ -300,6 +301,7 @@ public final class dev/mokksy/mokksy/MokksyServer : dev/mokksy/mokksy/MokksyHand
 	public fun <init> (Ljava/lang/String;IZLkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ljava/lang/String;IZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ldev/mokksy/mokksy/ServerConfiguration;)V
+	public final fun addListener (Ldev/mokksy/mokksy/RequestListener;)V
 	public final fun allStubs ()Ljava/util/List;
 	public final fun awaitStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun baseUrl ()Ljava/lang/String;
@@ -330,6 +332,7 @@ public final class dev/mokksy/mokksy/MokksyServer : dev/mokksy/mokksy/MokksyHand
 	public final fun method (Ldev/mokksy/mokksy/StubConfiguration;Lio/ktor/http/HttpMethod;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun method (Ljava/lang/String;Lio/ktor/http/HttpMethod;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public static synthetic fun method$default (Ldev/mokksy/mokksy/MokksyServer;Ljava/lang/String;Lio/ktor/http/HttpMethod;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/mokksy/mokksy/BuildingStep;
+	public final synthetic fun onResponseReady (Lkotlin/jvm/functions/Function3;)V
 	public final fun options (Ldev/mokksy/mokksy/StubConfiguration;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun options (Ldev/mokksy/mokksy/StubConfiguration;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun options (Ljava/lang/String;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
@@ -368,6 +371,10 @@ public final class dev/mokksy/mokksy/Mokksy_jvmKt {
 	public static final fun Mokksy (Ljava/lang/String;IZ)Ldev/mokksy/mokksy/MokksyServer;
 	public static final fun Mokksy (Ljava/lang/String;IZLkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/MokksyServer;
 	public static synthetic fun Mokksy$default (Ljava/lang/String;IZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/mokksy/mokksy/MokksyServer;
+}
+
+public abstract interface class dev/mokksy/mokksy/RequestListener {
+	public abstract fun onResponseReady (Ldev/mokksy/mokksy/request/RecordedRequest;Ldev/mokksy/mokksy/response/AbstractResponseDefinition;)V
 }
 
 public final class dev/mokksy/mokksy/ServerConfiguration {
@@ -873,6 +880,7 @@ public abstract class dev/mokksy/mokksy/response/AbstractResponseDefinition {
 	public fun getDelay-UwyO8pc ()J
 	public final fun getHeaders ()Lkotlin/jvm/functions/Function1;
 	public final fun getHttpStatus ()Lio/ktor/http/HttpStatusCode;
+	public final fun getHttpStatusCode ()I
 }
 
 public abstract class dev/mokksy/mokksy/response/AbstractResponseDefinitionBuilder {

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -78,6 +78,10 @@ final enum class dev.mokksy.mokksy/JournalMode : kotlin/Enum<dev.mokksy.mokksy/J
     final fun values(): kotlin/Array<dev.mokksy.mokksy/JournalMode> // dev.mokksy.mokksy/JournalMode.values|values#static(){}[0]
 }
 
+abstract fun interface dev.mokksy.mokksy/RequestListener { // dev.mokksy.mokksy/RequestListener|null[0]
+    abstract fun onResponseReady(dev.mokksy.mokksy.request/RecordedRequest, dev.mokksy.mokksy.response/AbstractResponseDefinition<*>) // dev.mokksy.mokksy/RequestListener.onResponseReady|onResponseReady(dev.mokksy.mokksy.request.RecordedRequest;dev.mokksy.mokksy.response.AbstractResponseDefinition<*>){}[0]
+}
+
 abstract interface dev.mokksy.mokksy/MokksyHandler { // dev.mokksy.mokksy/MokksyHandler|null[0]
     abstract val configuration // dev.mokksy.mokksy/MokksyHandler.configuration|{}configuration[0]
         abstract fun <get-configuration>(): dev.mokksy.mokksy/ServerConfiguration // dev.mokksy.mokksy/MokksyHandler.configuration.<get-configuration>|<get-configuration>(){}[0]
@@ -165,6 +169,8 @@ abstract class <#A: kotlin/Any?> dev.mokksy.mokksy.response/AbstractResponseDefi
         final fun <get-httpStatus>(): io.ktor.http/HttpStatusCode // dev.mokksy.mokksy.response/AbstractResponseDefinition.httpStatus.<get-httpStatus>|<get-httpStatus>(){}[0]
     open val delay // dev.mokksy.mokksy.response/AbstractResponseDefinition.delay|{}delay[0]
         open fun <get-delay>(): kotlin.time/Duration // dev.mokksy.mokksy.response/AbstractResponseDefinition.delay.<get-delay>|<get-delay>(){}[0]
+
+    final fun getHttpStatusCode(): kotlin/Int // dev.mokksy.mokksy.response/AbstractResponseDefinition.getHttpStatusCode|getHttpStatusCode(){}[0]
 }
 
 final class <#A: kotlin/Any> dev.mokksy.mokksy.request/BodySpecBuilder { // dev.mokksy.mokksy.request/BodySpecBuilder|null[0]
@@ -466,6 +472,7 @@ final class dev.mokksy.mokksy/MokksyServer : dev.mokksy.mokksy/MokksyHandler { /
     final fun <#A1: kotlin/Any> post(kotlin/String? = ..., kotlin.reflect/KClass<#A1>, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A1>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<#A1> // dev.mokksy.mokksy/MokksyServer.post|post(kotlin.String?;kotlin.reflect.KClass<0:0>;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any>}[0]
     final fun <#A1: kotlin/Any> put(dev.mokksy.mokksy/StubConfiguration, kotlin.reflect/KClass<#A1>, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A1>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<#A1> // dev.mokksy.mokksy/MokksyServer.put|put(dev.mokksy.mokksy.StubConfiguration;kotlin.reflect.KClass<0:0>;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any>}[0]
     final fun <#A1: kotlin/Any> put(kotlin/String? = ..., kotlin.reflect/KClass<#A1>, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A1>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<#A1> // dev.mokksy.mokksy/MokksyServer.put|put(kotlin.String?;kotlin.reflect.KClass<0:0>;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<0:0>,kotlin.Unit>){0§<kotlin.Any>}[0]
+    final fun addListener(dev.mokksy.mokksy/RequestListener) // dev.mokksy.mokksy/MokksyServer.addListener|addListener(dev.mokksy.mokksy.RequestListener){}[0]
     final fun allStubs(): kotlin.collections/List<dev.mokksy.mokksy/StubHandle> // dev.mokksy.mokksy/MokksyServer.allStubs|allStubs(){}[0]
     final fun baseUrl(): kotlin/String // dev.mokksy.mokksy/MokksyServer.baseUrl|baseUrl(){}[0]
     final fun checkForUnmatchedRequests() // dev.mokksy.mokksy/MokksyServer.checkForUnmatchedRequests|checkForUnmatchedRequests(){}[0]
@@ -481,6 +488,7 @@ final class dev.mokksy.mokksy/MokksyServer : dev.mokksy.mokksy/MokksyHandler { /
     final fun getStub(kotlin/String): dev.mokksy.mokksy/StubHandle // dev.mokksy.mokksy/MokksyServer.getStub|getStub(kotlin.String){}[0]
     final fun head(dev.mokksy.mokksy/StubConfiguration, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.head|head(dev.mokksy.mokksy.StubConfiguration;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
     final fun head(kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.head|head(kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
+    final fun onResponseReady(kotlin.coroutines/SuspendFunction2<dev.mokksy.mokksy.request/RecordedRequest, dev.mokksy.mokksy.response/AbstractResponseDefinition<*>, kotlin/Unit>) // dev.mokksy.mokksy/MokksyServer.onResponseReady|onResponseReady(kotlin.coroutines.SuspendFunction2<dev.mokksy.mokksy.request.RecordedRequest,dev.mokksy.mokksy.response.AbstractResponseDefinition<*>,kotlin.Unit>){}[0]
     final fun options(dev.mokksy.mokksy/StubConfiguration, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.options|options(dev.mokksy.mokksy.StubConfiguration;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
     final fun options(kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.options|options(kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
     final fun patch(dev.mokksy.mokksy/StubConfiguration, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.patch|patch(dev.mokksy.mokksy.StubConfiguration;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
@@ -8,6 +8,7 @@ import dev.mokksy.mokksy.request.RequestSpecification
 import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import dev.mokksy.mokksy.request.handleRequest
 import dev.mokksy.mokksy.request.methodEqual
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpMethod.Companion.Delete
@@ -22,11 +23,14 @@ import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.routing.RoutingContext
 import io.ktor.util.logging.Logger
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmSynthetic
 import kotlin.reflect.KClass
 
 /**
@@ -95,6 +99,12 @@ public class MokksyServer
         private val requestJournal: RequestJournal =
             RequestJournal(configuration.journalMode)
 
+        private val responseListener: AtomicRef<
+            (
+                suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit
+            )?,
+        > = atomic(null)
+
         private val started = CompletableDeferred<Unit>()
 
         private val server:
@@ -117,6 +127,7 @@ public class MokksyServer
                 requestJournal = requestJournal,
                 configuration = configuration,
                 formatter = httpFormatter,
+                responseListener = responseListener.value,
             )
         }
 
@@ -158,6 +169,61 @@ public class MokksyServer
         public suspend fun awaitStarted(): MokksyServer {
             started.await()
             return this
+        }
+
+        /**
+         * Registers a listener that is invoked when a matched stub is about to send its response.
+         *
+         * The listener fires after response headers and status have been applied,
+         * but before the response body is written. This allows test assertions on
+         * shared state (e.g., semaphore permits) at the exact moment a response is
+         * ready to be sent on the wire.
+         *
+         * Example:
+         * ```kotlin
+         * mokksyServer.onResponseReady { request, response ->
+         *     semaphore.availablePermits shouldBe 0
+         * }
+         * ```
+         *
+         * Only a single listener may be registered. Subsequent calls replace the previous one.
+         *
+         * @param listener A suspend lambda receiving the [RecordedRequest] and the
+         *   [AbstractResponseDefinition] about to be sent.
+         * @see MokksyServer.addListener For non-suspend usage from Java or Kotlin.
+         */
+        @JvmSynthetic
+        @ExperimentalMokksyApi
+        public fun onResponseReady(
+            listener: suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit,
+        ) {
+            responseListener.value = listener
+        }
+
+        /**
+         * Registers a listener that is invoked when a matched stub is about to send its response.
+         *
+         * Accepts a [RequestListener] — works from both Kotlin and Java.
+         *
+         * Prefer [onResponseReady] from Kotlin for suspend-aware usage.
+         *
+         * Example (Java):
+         * ```java
+         * mokksy.addListener((request, response) -> {
+         *     assertThat(request.getUri()).isEqualTo("/path");
+         * });
+         * ```
+         *
+         * Only a single listener may be registered. Subsequent calls replace the previous one.
+         *
+         * @param listener The [RequestListener] whose [RequestListener.onResponseReady]
+         *   will be called when a stub response is ready.
+         */
+        @ExperimentalMokksyApi
+        public fun addListener(listener: RequestListener) {
+            responseListener.value = { request, response ->
+                listener.onResponseReady(request, response)
+            }
         }
 
         /**

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/RequestListener.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/RequestListener.kt
@@ -1,0 +1,36 @@
+package dev.mokksy.mokksy
+
+import dev.mokksy.mokksy.request.RecordedRequest
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
+
+/**
+ * A listener invoked when a matched stub is about to send its response.
+ *
+ * This is a Java-friendly alternative to the suspend-lambda [MokksyServer.onResponseReady] overload.
+ *
+ * Example (Java):
+ * ```java
+ * mokksy.addListener((request, response) -> {
+ *     assertThat(request.getUri()).isEqualTo("/path");
+ * });
+ * ```
+ *
+ * @see MokksyServer.addListener
+ * @see MokksyServer.onResponseReady
+ */
+@ExperimentalMokksyApi
+public fun interface RequestListener {
+    /**
+     * Called when a matched stub is about to send its response.
+     *
+     * The listener fires after response headers and status have been applied,
+     * but before the response body is written.
+     *
+     * @param request The recorded incoming request.
+     * @param response The response definition that will be sent.
+     */
+    public fun onResponseReady(
+        request: RecordedRequest,
+        response: AbstractResponseDefinition<*>,
+    )
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Stub.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Stub.kt
@@ -2,9 +2,12 @@
 
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RecordedRequest
 import dev.mokksy.mokksy.request.RequestSpecification
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
 import dev.mokksy.mokksy.response.ResponseDefinitionSupplier
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.routing.RoutingRequest
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
@@ -116,10 +119,16 @@ internal data class Stub<P : Any, T : Any>(
     suspend fun respond(
         call: ApplicationCall,
         verbose: Boolean,
+        routingRequest: RoutingRequest,
+        responseListener: (suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit)? = null,
     ) {
         val responseDefinition = responseDefinitionSupplier.invoke(call)
         responseDefinition.headers?.invoke(call.response.headers)
         call.response.status(responseDefinition.httpStatus)
+
+        responseListener?.let {
+            it(RecordedRequest.from(routingRequest, matched = true), responseDefinition)
+        }
 
         responseDefinition.writeResponse(call, verbose)
     }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestHandler.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestHandler.kt
@@ -6,6 +6,7 @@ import dev.mokksy.mokksy.InternalMokksyApi
 import dev.mokksy.mokksy.ServerConfiguration
 import dev.mokksy.mokksy.Stub
 import dev.mokksy.mokksy.StubRegistry
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
@@ -36,6 +37,7 @@ internal suspend fun handleRequest(
     requestJournal: RequestJournal,
     configuration: ServerConfiguration,
     formatter: HttpFormatter,
+    responseListener: (suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit)? = null,
 ) {
     val request = context.call.request
 
@@ -58,6 +60,7 @@ internal suspend fun handleRequest(
             request = request,
             context = context,
             formatter = formatter,
+            responseListener = responseListener,
         )
     } else {
         if (requestJournal.recordsUnmatched) {
@@ -102,6 +105,7 @@ private suspend fun handleMatchedStub(
     request: RoutingRequest,
     context: RoutingContext,
     formatter: HttpFormatter,
+    responseListener: (suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit)? = null,
 ) {
     val config = matchedStub.configuration
     val verbose = serverConfig.verbose || config.verbose
@@ -116,6 +120,6 @@ private suspend fun handleMatchedStub(
                 }\n---\n${this.toLogString()}",
             )
         }
-        respond(context.call, verbose)
+        respond(context.call, verbose, routingRequest = request, responseListener = responseListener)
     }
 }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinition.kt
@@ -35,6 +35,11 @@ public abstract class AbstractResponseDefinition<T>(
     public val headers: (ResponseHeaders.() -> Unit)? = null,
     public open val delay: Duration = Duration.ZERO,
 ) {
+    /**
+     * Returns the HTTP status code as an integer.
+     */
+    public fun getHttpStatusCode(): Int = httpStatus.value
+
     internal abstract suspend fun writeResponse(
         call: ApplicationCall,
         verbose: Boolean,

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
@@ -10,6 +10,8 @@ import dev.mokksy.mokksy.StubConfiguration
 import dev.mokksy.mokksy.StubHandle
 import dev.mokksy.mokksy.loadStubsFromEnv
 import dev.mokksy.mokksy.loadStubsFromFile
+import dev.mokksy.mokksy.ExperimentalMokksyApi
+import dev.mokksy.mokksy.RequestListener
 import dev.mokksy.mokksy.request.RecordedRequest
 import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import dev.mokksy.mokksy.start
@@ -768,6 +770,27 @@ public class Mokksy(
         requestType: KClass<P>,
         block: RequestSpecificationBuilder<P>.() -> Unit,
     ): BuildingStep<P> = delegate.method(configuration, Options, requestType, block)
+
+    // endregion
+
+    // region Response listener
+
+    /**
+     * Registers a listener that is invoked when a matched stub is about to send its response.
+     *
+     * Example:
+     * ```java
+     * mokksy.addListener((request, response) -> {
+     *     assertThat(request.getUri()).isEqualTo("/path");
+     * });
+     * ```
+     *
+     * @param listener The [RequestListener] to invoke.
+     */
+    @ExperimentalMokksyApi
+    public fun addListener(listener: RequestListener) {
+        delegate.addListener(listener)
+    }
 
     // endregion
 

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.jvm.kt
@@ -18,7 +18,7 @@ public fun File.asBase64DataUrl(
 @JvmOverloads
 public fun Path.asBase64DataUrl(
     mimeType: MimeType =
-        ContentType.Companion
+        ContentType
             .defaultForFilePath(
                 fileName.toString(),
             ).asMimeType(),

--- a/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaLifecycleIT.java
+++ b/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaLifecycleIT.java
@@ -29,11 +29,8 @@ public class MokksyServerJavaLifecycleIT {
 
     @Test
     public void closeShutsDownTheServer() {
-        var mokksy = Mokksy.create().start();
-        try {
+        try (var mokksy = Mokksy.create().start()) {
             assertThat(mokksy.port()).isGreaterThan(0);
-        } finally {
-            mokksy.close();
         }
     }
 

--- a/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaListenerIT.java
+++ b/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaListenerIT.java
@@ -24,7 +24,7 @@ public class MokksyServerJavaListenerIT {
             mokksy.addListener((request, response) -> {
                 callCount.incrementAndGet();
                 assertThat(request.getUri()).isEqualTo("/java-listener-test");
-                assertThat(response.getHttpStatus().getValue()).isEqualTo(200);
+                assertThat(response.getHttpStatusCode()).isEqualTo(200);
             });
 
             mokksy.get("/java-listener-test")

--- a/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaListenerIT.java
+++ b/mokksy/src/jvmTest/java/dev/mokksy/mokksy/MokksyServerJavaListenerIT.java
@@ -1,0 +1,103 @@
+package dev.mokksy.mokksy;
+
+import dev.mokksy.Mokksy;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MokksyServerJavaListenerIT {
+
+    @Test
+    public void addListenerFiresWhenStubMatches() throws Exception {
+        var mokksy = Mokksy.create().start();
+        var httpClient = HttpClient.newHttpClient();
+
+        try {
+            var callCount = new AtomicInteger(0);
+
+            mokksy.addListener((request, response) -> {
+                callCount.incrementAndGet();
+                assertThat(request.getUri()).isEqualTo("/java-listener-test");
+                assertThat(response.getHttpStatus().getValue()).isEqualTo(200);
+            });
+
+            mokksy.get("/java-listener-test")
+                .respondsWith("ok");
+
+            var serverResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create(mokksy.baseUrl() + "/java-listener-test"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(serverResponse.statusCode()).isEqualTo(200);
+            assertThat(serverResponse.body()).isEqualTo("ok");
+            assertThat(callCount.get()).isEqualTo(1);
+        } finally {
+            mokksy.shutdown();
+        }
+    }
+
+    @Test
+    public void addListenerIsNotInvokedForUnmatchedRequests() throws Exception {
+        var mokksy = Mokksy.create().start();
+        var httpClient = HttpClient.newHttpClient();
+
+        try {
+            var callCount = new AtomicInteger(0);
+
+            mokksy.addListener((request, response) -> callCount.incrementAndGet());
+
+            var serverResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create(mokksy.baseUrl() + "/unmatched-java-listener"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(serverResponse.statusCode()).isEqualTo(404);
+            assertThat(callCount.get()).isEqualTo(0);
+        } finally {
+            mokksy.shutdown();
+        }
+    }
+
+    @Test
+    public void addListenerIsReplaceable() throws Exception {
+        var mokksy = Mokksy.create().start();
+        var httpClient = HttpClient.newHttpClient();
+
+        try {
+            var firstCallCount = new AtomicInteger(0);
+            var secondCallCount = new AtomicInteger(0);
+
+            mokksy.addListener((request, response) -> firstCallCount.incrementAndGet());
+            mokksy.addListener((request, response) -> secondCallCount.incrementAndGet());
+
+            mokksy.get("/java-replace-listener")
+                .respondsWith("ok");
+
+            httpClient.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create(mokksy.baseUrl() + "/java-replace-listener"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(firstCallCount.get()).isEqualTo(0);
+            assertThat(secondCallCount.get()).isEqualTo(1);
+        } finally {
+            mokksy.shutdown();
+        }
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/JavaRequestSpecificationBuilderTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/JavaRequestSpecificationBuilderTest.kt
@@ -7,8 +7,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.contain
 import io.kotest.matchers.types.shouldBeSameInstanceAs
-import java.util.function.Consumer
-import java.util.function.Predicate
 import kotlin.test.Test
 
 @OptIn(ExperimentalMokksyApi::class)
@@ -56,7 +54,7 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `body with Consumer configures form and returns this`() {
-        val result = sut.body(Consumer { b -> b.form { form -> form.field("key", "value") } })
+        val result = sut.body { b -> b.form { form -> form.field("key", "value") } }
         assertSoftly {
             result shouldBe sut
             delegate.build().formSpecs shouldHaveSize 1
@@ -65,7 +63,7 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `body with Consumer configures predicate and returns this`() {
-        val result = sut.body(Consumer { b -> b.predicate { it.isNotEmpty() } })
+        val result = sut.body { b -> b.predicate { it.isNotEmpty() } }
         assertSoftly {
             result shouldBe sut
             delegate.build().body shouldHaveSize 1
@@ -74,10 +72,10 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `body with Consumer configures both form and predicate`() {
-        sut.body(Consumer { b ->
+        sut.body { b ->
             b.form { form -> form.field("key", "value") }
             b.predicate { it.isNotEmpty() }
-        })
+        }
         val built = delegate.build()
         assertSoftly {
             built.formSpecs shouldHaveSize 1
@@ -120,7 +118,7 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `bodyTextMatches with Predicate adds body string matcher and returns this`() {
-        val result = sut.bodyTextMatches(Predicate<String?> { it != null && it.contains("token") })
+        val result = sut.bodyTextMatches { it != null && it.contains("token") }
         assertSoftly {
             result shouldBe sut
             delegate.build().bodyString shouldHaveSize 1
@@ -130,7 +128,7 @@ class JavaRequestSpecificationBuilderTest {
     @Test
     fun `bodyTextMatches with description adds body string matcher and returns this`() {
         val result =
-            sut.bodyTextMatches("contains token", Predicate<String?> { it != null && it.contains("token") })
+            sut.bodyTextMatches("contains token") { it != null && it.contains("token") }
         assertSoftly {
             result shouldBe sut
             delegate.build().bodyString shouldHaveSize 1
@@ -151,8 +149,8 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `multiple body calls add multiple matchers`() {
-        sut.bodyTextMatches(Predicate<String?> { it != null && it.contains("foo") })
-        sut.bodyTextMatches(Predicate<String?> { it != null && it.contains("bar") })
+        sut.bodyTextMatches { it != null && it.contains("foo") }
+        sut.bodyTextMatches { it != null && it.contains("bar") }
         val built = delegate.build()
         assertSoftly {
             built.bodyString shouldHaveSize 2
@@ -165,9 +163,12 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `body Predicate null body does not match`() {
-        sut.bodyTextMatches(Predicate<String?> { it != null && it.isNotEmpty() })
+        sut.bodyTextMatches { it != null && it.isNotEmpty() }
         val built = delegate.build()
-        built.bodyString.single().test(null).passed() shouldBe false
+        built.bodyString
+            .single()
+            .test(null)
+            .passed() shouldBe false
     }
 
     // endregion
@@ -198,7 +199,7 @@ class JavaRequestSpecificationBuilderTest {
 
     @Test
     fun `cookieMatches adds cookie matcher and returns this`() {
-        val result = sut.cookieMatches("session", Predicate<String?> { it?.startsWith("abc") == true })
+        val result = sut.cookieMatches("session") { it?.startsWith("abc") == true }
         assertSoftly {
             result shouldBe sut
             delegate.build().cookies shouldHaveSize 1

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
@@ -1,5 +1,9 @@
+@file:OptIn(ExperimentalMokksyApi::class)
+
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RecordedRequest
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -192,6 +196,88 @@ internal class MokksyServerIT : AbstractIT() {
         client.get(path)
 
         mokksy.findAllUnmatchedRequests() shouldHaveSize 1
+    }
+
+    // endregion
+
+    // region onResponseReady listener
+
+    @Test
+    suspend fun `onResponseReady listener fires with request and response when a stub matches`() {
+        val path = "/listener-request-response-$seed"
+        val captured = mutableListOf<Pair<RecordedRequest, AbstractResponseDefinition<*>>>()
+
+        mokksy.onResponseReady { request, response ->
+            captured.add(request to response)
+        }
+
+        mokksy.get {
+            path(path)
+        } respondsWith {
+            body = "listener-ok"
+        }
+
+        client.get(path)
+
+        captured shouldHaveSize 1
+        captured[0].first.uri shouldBe path
+        captured[0].second.httpStatus shouldBe HttpStatusCode.OK
+        captured[0].second.getHttpStatusCode() shouldBe HttpStatusCode.OK.value
+    }
+
+    @Test
+    suspend fun `addListener with RequestListener fires correctly from Kotlin`() {
+        val path = "/add-listener-$seed"
+        val captured = mutableListOf<Pair<RecordedRequest, AbstractResponseDefinition<*>>>()
+
+        mokksy.addListener { request, response ->
+            captured.add(request to response)
+        }
+
+        mokksy.get {
+            path(path)
+        } respondsWith {
+            body = "listener-ok"
+        }
+
+        client.get(path)
+
+        captured shouldHaveSize 1
+        captured[0].first.uri shouldBe path
+        captured[0].second.httpStatus shouldBe HttpStatusCode.OK
+    }
+
+    @Test
+    suspend fun `onResponseReady listener is not invoked for unmatched requests`() {
+        val captured = mutableListOf<RecordedRequest>()
+
+        mokksy.onResponseReady { request, _ ->
+            captured.add(request)
+        }
+
+        client.get("/unmatched-listener-$seed")
+
+        captured.shouldBeEmpty()
+    }
+
+    @Test
+    suspend fun `onResponseReady is replaceable`() {
+        var firstCalled = false
+        var secondCalled = false
+
+        mokksy.onResponseReady { _, _ -> firstCalled = true }
+        mokksy.onResponseReady { _, _ -> secondCalled = true }
+
+        mokksy.get {
+            path("/replace-listener-$seed")
+        } respondsWith {
+            body = "ok"
+        }
+
+        client.get("/replace-listener-$seed")
+
+        firstCalled shouldBe false
+        secondCalled shouldBe true
     }
 
     // endregion

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksySseIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksySseIT.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.AfterTest
 import kotlin.text.Charsets.UTF_8
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 internal class MokksySseIT : AbstractIT({ createKtorSSEClient(it) }) {
     @Test
@@ -144,5 +145,5 @@ suspend fun main() {
             }
     }
 
-    delay(1000_000L)
+    delay(1000.seconds)
 }

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighterTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/utils/highlight/JsonStringHighlighterTest.kt
@@ -13,10 +13,10 @@ private const val BLUE = "\u001B[34m"
 private const val YELLOW = "\u001B[33m"
 
 // Each colorized fragment is preceded by a reset to clear any preceding attributes.
-private val RM = "$RESET$MAGENTA"
-private val RG = "$RESET$GREEN"
-private val RB = "$RESET$BLUE"
-private val RY = "$RESET$YELLOW"
+private const val RM = "$RESET$MAGENTA"
+private const val RG = "$RESET$GREEN"
+private const val RB = "$RESET$BLUE"
+private const val RY = "$RESET$YELLOW"
 
 @Suppress("MaxLineLength")
 class JsonStringHighlighterTest {


### PR DESCRIPTION
Closes #153

## Summary

Add an `onResponseReady` callback to `MokksyServer` that fires when a matched stub is about to send its response — after headers/status are applied, before the body is written. Designed for test-time assertions on shared state (e.g., semaphore permits) at the exact moment a response is ready.

## API

- `MokksyServer.onResponseReady { request, response -> }` — suspend lambda, Kotlin-only (`@JvmSynthetic`)
- `fun interface RequestListener` — non-suspend SAM interface
- `MokksyServer.addListener(RequestListener)` — works from both Kotlin (SAM) and Java (lambda)
- `Mokksy.addListener(RequestListener)` — Java wrapper delegation
- `AbstractResponseDefinition.getHttpStatusCode(): Int` — convenience for Java callers

## Implementation

- Listener stored in `AtomicRef` for thread-safe single-listener semantics (calling it again replaces the previous)
- Listener threaded through `handleRequest` → `handleMatchedStub` → `Stub.respond`
- Listener is read as a snapshot per-request; in-flight requests are not affected by replacement
- Renamed `MockServiceRequestListener` → `RequestListener`

## Tests

### Kotlin (MokksyServerIT.kt)
- Suspend lambda fires on match with correct request/response
- `RequestListener` SAM fires correctly from Kotlin
- Listener not invoked for unmatched requests
- Listener is replaceable (last wins)

### Java (MokksyServerJavaListenerIT.java)
- `addListener` fires on match
- Not invoked for unmatched requests
- Replaceable (last wins)

## Review findings addressed

- `@ExperimentalMokksyApi` added to `Mokksy.addListener` (was only on `MokksyServer.addListener`)
- `MockServiceRequestListener` renamed to `RequestListener` (shorter, cleaner)
- KDocs cross-reference `onResponseReady` ↔ `addListener` with usage guidance