### PR TITLE
feat: #74 more stub lookup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,15 +890,21 @@ stub.verifyCalled().never();                 // never called
 stub.verifyCalled(3);                        // convenience shortcut
 ```
 
-For named stubs, you can also look them up later via `getStub`:
+For named stubs, you can also look them up later via `findStubByName`:
 
 ```kotlin
-val handle = mokksy.getStub("create-item")
-handle.verifyCalled().exactly(1)
+val handle = mokksy.findStubByName("create-item")
+handle?.verifyCalled()?.exactly(1)
 ```
 
-`getStub` throws `NoSuchElementException` if no stub with that name is registered
-or if the stub was already removed.
+`findStubByName` returns `null` if no stub with that name is registered or has been removed.
+Use `findStubById` to look up a stub by its stable unique id, or `findStubs { ... }` to
+filter by arbitrary criteria:
+
+```kotlin
+val byId: StubHandle? = mokksy.findStubById(handle.id)
+val unmatched: List<StubHandle> = mokksy.findStubs { it.matchCount() == 0 }
+```
 
 List all registered stubs with `allStubs()`:
 

--- a/integration-tests/src/commonTest/kotlin/dev/mokksy/it/StubVerificationIT.kt
+++ b/integration-tests/src/commonTest/kotlin/dev/mokksy/it/StubVerificationIT.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import kotlin.test.Test
@@ -125,15 +126,13 @@ internal class StubVerificationIT : MokksyIntegrationTest() {
         }
 
     @Test
-    fun `getStub returns null for unknown name`() =
+    fun `findStubByName returns null for unknown name`() =
         runIntegrationTest {
-            shouldThrow<NoSuchElementException> {
-                mokksy.getStub("nonexistent")
-            }
+            mokksy.findStubByName("nonexistent") shouldBe null
         }
 
     @Test
-    fun `getStub returns handle for named stub`() =
+    fun `findStubByName returns handle for named stub`() =
         runIntegrationTest {
             val stub =
                 mokksy
@@ -141,13 +140,15 @@ internal class StubVerificationIT : MokksyIntegrationTest() {
                         path("/find-stub-by-name")
                     }.respondsWith { body = "ok" }
 
-            val found = mokksy.getStub("find-stub-by-name")
-            found.name shouldBe "find-stub-by-name"
-            found.matchCount() shouldBe 0
+            val found = mokksy.findStubByName("find-stub-by-name")
+            found.shouldNotBeNull {
+                name shouldBe "find-stub-by-name"
+                matchCount() shouldBe 0
+            }
 
             client.get(mokksy.baseUrl() + "/find-stub-by-name")
             stub.matchCount() shouldBe 1
-            found.matchCount() shouldBe 1
+            found?.matchCount() shouldBe 1
         }
 
     @Test

--- a/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaStubLookupIT.java
+++ b/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaStubLookupIT.java
@@ -1,0 +1,159 @@
+package dev.mokksy.it;
+
+import dev.mokksy.Mokksy;
+import dev.mokksy.mokksy.ExperimentalMokksyApi;
+import dev.mokksy.mokksy.StubConfiguration;
+import dev.mokksy.mokksy.StubPredicate;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExperimentalMokksyApi
+class MokksyJavaStubLookupIT {
+
+    @Test
+    void findStubById_shouldReturnHandleForRegisteredStub() throws Exception {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            HttpClient httpClient = HttpClient.newHttpClient();
+
+            var handle = mokksy.get(spec -> spec.path("/find-by-id"))
+                .respondsWith(builder -> builder.body("ok"));
+
+            assertThat(handle).isNotNull();
+            assertThat(handle.getId()).isNotEmpty();
+
+            var found = mokksy.findStubById(handle.getId());
+            assertThat(found).isNotNull();
+            assertThat(found.getId()).isEqualTo(handle.getId());
+            assertThat(found.matchCount()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void findStubById_shouldReturnNullForUnknownId() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            var found = mokksy.findStubById("nonexistent-id");
+            assertThat(found).isNull();
+        }
+    }
+
+    @Test
+    void findStubByName_shouldReturnHandleForNamedStub() throws Exception {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            HttpClient httpClient = HttpClient.newHttpClient();
+
+            mokksy.get(new StubConfiguration("lookup-by-name"), spec ->
+                    spec.path("/lookup-by-name")
+                ).respondsWith(builder -> builder.body("ok"));
+
+            var found = mokksy.findStubByName("lookup-by-name");
+            assertThat(found).isNotNull();
+            assertThat(found.getName()).isEqualTo("lookup-by-name");
+            assertThat(found.matchCount()).isEqualTo(0);
+            assertThat(found.getId()).isNotNull();
+
+            httpClient.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create(mokksy.baseUrl() + "/lookup-by-name"))
+                    .GET().build(),
+                HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(found.matchCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void findStubByName_shouldReturnNullForUnknownName() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            var found = mokksy.findStubByName("nonexistent");
+            assertThat(found).isNull();
+        }
+    }
+
+    @Test
+    void findStubByBothIdAndName_shouldReturnSameStub() throws Exception {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            HttpClient httpClient = HttpClient.newHttpClient();
+
+            var handle = mokksy.get(new StubConfiguration("dual-lookup"), spec ->
+                    spec.path("/dual-lookup")
+                ).respondsWith(builder -> builder.body("ok"));
+
+            var byId = mokksy.findStubById(handle.getId());
+            var byName = mokksy.findStubByName("dual-lookup");
+
+            assertThat(byId).isNotNull();
+            assertThat(byName).isNotNull();
+            assertThat(byId.getId()).isEqualTo(byName.getId());
+            assertThat(byId.getName()).isEqualTo(byName.getName());
+
+            httpClient.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create(mokksy.baseUrl() + "/dual-lookup"))
+                    .GET().build(),
+                HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(byId.matchCount()).isEqualTo(1);
+            assertThat(byName.matchCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void findStub_withPredicate_shouldReturnFirstMatch() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            mokksy.get(spec -> spec.path("/predicate-a"))
+                .respondsWith(builder -> builder.body("a"));
+            mokksy.get(spec -> spec.path("/predicate-b"))
+                .respondsWith(builder -> builder.body("b"));
+
+            StubPredicate anyStub = stub -> !stub.getId().isEmpty();
+            var found = mokksy.findStub(anyStub);
+            assertThat(found).isNotNull();
+            assertThat(found.getId()).isNotEmpty();
+        }
+    }
+
+    @Test
+    void findStub_withPredicate_shouldReturnNullWhenNoMatch() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            mokksy.get(spec -> spec.path("/no-predicate-match"))
+                .respondsWith(builder -> builder.body("ok"));
+
+            var found = mokksy.findStub(stub -> "missing".equals(stub.getName()));
+            assertThat(found).isNull();
+        }
+    }
+
+    @Test
+    void findStubs_withPredicate_shouldReturnAllMatches() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            mokksy.get(new StubConfiguration("java-match-a"), spec -> spec.path("/java-match-a"))
+                .respondsWith(builder -> builder.body("a"));
+            mokksy.get(new StubConfiguration("java-match-b"), spec -> spec.path("/java-match-b"))
+                .respondsWith(builder -> builder.body("b"));
+            mokksy.get(new StubConfiguration("java-other"), spec -> spec.path("/java-other"))
+                .respondsWith(builder -> builder.body("other"));
+
+            var matches = mokksy.findStubs(stub -> stub.getName() != null && stub.getName().startsWith("java-match-"));
+            assertThat(matches).hasSize(2);
+        }
+    }
+
+    @Test
+    void findStubs_withPredicate_shouldReturnEmptyListWhenNoMatch() {
+        try (Mokksy mokksy = Mokksy.create().start()) {
+            mokksy.get(spec -> spec.path("/java-nothing"))
+                .respondsWith(builder -> builder.body("ok"));
+
+            var matches = mokksy.findStubs(stub -> "missing".equals(stub.getName()));
+            assertThat(matches).isEmpty();
+        }
+    }
+}

--- a/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaStubLookupIT.java
+++ b/integration-tests/src/jvmTest/java/dev/mokksy/it/MokksyJavaStubLookupIT.java
@@ -19,7 +19,6 @@ class MokksyJavaStubLookupIT {
     @Test
     void findStubById_shouldReturnHandleForRegisteredStub() throws Exception {
         try (Mokksy mokksy = Mokksy.create().start()) {
-            HttpClient httpClient = HttpClient.newHttpClient();
 
             var handle = mokksy.get(spec -> spec.path("/find-by-id"))
                 .respondsWith(builder -> builder.body("ok"));

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -32,6 +32,10 @@ public final class dev/mokksy/Mokksy : java/lang/AutoCloseable {
 	public final synthetic fun delete (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun findAllUnexpectedRequests ()Ljava/util/List;
 	public final fun findAllUnmatchedStubs ()Ljava/util/List;
+	public final fun findStub (Ldev/mokksy/mokksy/StubPredicate;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubById (Ljava/lang/String;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubByName (Ljava/lang/String;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubs (Ldev/mokksy/mokksy/StubPredicate;)Ljava/util/List;
 	public final fun get (Ldev/mokksy/mokksy/StubConfiguration;Ljava/lang/Class;Ljava/util/function/Consumer;)Ldev/mokksy/mokksy/JavaBuildingStep;
 	public final fun get (Ldev/mokksy/mokksy/StubConfiguration;Ljava/lang/String;)Ldev/mokksy/mokksy/JavaBuildingStep;
 	public final fun get (Ldev/mokksy/mokksy/StubConfiguration;Ljava/util/function/Consumer;)Ldev/mokksy/mokksy/JavaBuildingStep;
@@ -316,6 +320,10 @@ public final class dev/mokksy/mokksy/MokksyServer : dev/mokksy/mokksy/MokksyHand
 	public final fun findAllUnexpectedRequests ()Ljava/util/List;
 	public final fun findAllUnmatchedRequests ()Ljava/util/List;
 	public final fun findAllUnmatchedStubs ()Ljava/util/List;
+	public final fun findStub (Ldev/mokksy/mokksy/StubPredicate;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubById (Ljava/lang/String;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubByName (Ljava/lang/String;)Ldev/mokksy/mokksy/StubHandle;
+	public final fun findStubs (Ldev/mokksy/mokksy/StubPredicate;)Ljava/util/List;
 	public final fun get (Ldev/mokksy/mokksy/StubConfiguration;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun get (Ldev/mokksy/mokksy/StubConfiguration;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
 	public final fun get (Ljava/lang/String;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/BuildingStep;
@@ -456,11 +464,16 @@ public final class dev/mokksy/mokksy/StubConfiguration$Companion {
 }
 
 public final class dev/mokksy/mokksy/StubHandle {
+	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun matchCount ()J
 	public fun toString ()Ljava/lang/String;
 	public final fun verifyCalled ()Ldev/mokksy/mokksy/VerificationBuilder;
 	public final fun verifyCalled (I)Ldev/mokksy/mokksy/StubHandle;
+}
+
+public abstract interface class dev/mokksy/mokksy/StubPredicate {
+	public abstract fun test (Ldev/mokksy/mokksy/StubHandle;)Z
 }
 
 public final class dev/mokksy/mokksy/VerificationBuilder {

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -82,6 +82,10 @@ abstract fun interface dev.mokksy.mokksy/RequestListener { // dev.mokksy.mokksy/
     abstract fun onResponseReady(dev.mokksy.mokksy.request/RecordedRequest, dev.mokksy.mokksy.response/AbstractResponseDefinition<*>) // dev.mokksy.mokksy/RequestListener.onResponseReady|onResponseReady(dev.mokksy.mokksy.request.RecordedRequest;dev.mokksy.mokksy.response.AbstractResponseDefinition<*>){}[0]
 }
 
+abstract fun interface dev.mokksy.mokksy/StubPredicate { // dev.mokksy.mokksy/StubPredicate|null[0]
+    abstract fun test(dev.mokksy.mokksy/StubHandle): kotlin/Boolean // dev.mokksy.mokksy/StubPredicate.test|test(dev.mokksy.mokksy.StubHandle){}[0]
+}
+
 abstract interface dev.mokksy.mokksy/MokksyHandler { // dev.mokksy.mokksy/MokksyHandler|null[0]
     abstract val configuration // dev.mokksy.mokksy/MokksyHandler.configuration|{}configuration[0]
         abstract fun <get-configuration>(): dev.mokksy.mokksy/ServerConfiguration // dev.mokksy.mokksy/MokksyHandler.configuration.<get-configuration>|<get-configuration>(){}[0]
@@ -483,6 +487,10 @@ final class dev.mokksy.mokksy/MokksyServer : dev.mokksy.mokksy/MokksyHandler { /
     final fun findAllUnexpectedRequests(): kotlin.collections/List<dev.mokksy.mokksy.request/RecordedRequest> // dev.mokksy.mokksy/MokksyServer.findAllUnexpectedRequests|findAllUnexpectedRequests(){}[0]
     final fun findAllUnmatchedRequests(): kotlin.collections/List<dev.mokksy.mokksy.request/RecordedRequest> // dev.mokksy.mokksy/MokksyServer.findAllUnmatchedRequests|findAllUnmatchedRequests(){}[0]
     final fun findAllUnmatchedStubs(): kotlin.collections/List<dev.mokksy.mokksy/StubHandle> // dev.mokksy.mokksy/MokksyServer.findAllUnmatchedStubs|findAllUnmatchedStubs(){}[0]
+    final fun findStub(dev.mokksy.mokksy/StubPredicate): dev.mokksy.mokksy/StubHandle? // dev.mokksy.mokksy/MokksyServer.findStub|findStub(dev.mokksy.mokksy.StubPredicate){}[0]
+    final fun findStubById(kotlin/String): dev.mokksy.mokksy/StubHandle? // dev.mokksy.mokksy/MokksyServer.findStubById|findStubById(kotlin.String){}[0]
+    final fun findStubByName(kotlin/String): dev.mokksy.mokksy/StubHandle? // dev.mokksy.mokksy/MokksyServer.findStubByName|findStubByName(kotlin.String){}[0]
+    final fun findStubs(dev.mokksy.mokksy/StubPredicate): kotlin.collections/List<dev.mokksy.mokksy/StubHandle> // dev.mokksy.mokksy/MokksyServer.findStubs|findStubs(dev.mokksy.mokksy.StubPredicate){}[0]
     final fun get(dev.mokksy.mokksy/StubConfiguration, kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.get|get(dev.mokksy.mokksy.StubConfiguration;kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
     final fun get(kotlin/Function1<dev.mokksy.mokksy.request/RequestSpecificationBuilder<kotlin/String>, kotlin/Unit>): dev.mokksy.mokksy/BuildingStep<kotlin/String> // dev.mokksy.mokksy/MokksyServer.get|get(kotlin.Function1<dev.mokksy.mokksy.request.RequestSpecificationBuilder<kotlin.String>,kotlin.Unit>){}[0]
     final fun getStub(kotlin/String): dev.mokksy.mokksy/StubHandle // dev.mokksy.mokksy/MokksyServer.getStub|getStub(kotlin.String){}[0]
@@ -560,6 +568,8 @@ final class dev.mokksy.mokksy/StubConfiguration { // dev.mokksy.mokksy/StubConfi
 }
 
 final class dev.mokksy.mokksy/StubHandle { // dev.mokksy.mokksy/StubHandle|null[0]
+    final val id // dev.mokksy.mokksy/StubHandle.id|{}id[0]
+        final fun <get-id>(): kotlin/String // dev.mokksy.mokksy/StubHandle.id.<get-id>|<get-id>(){}[0]
     final val name // dev.mokksy.mokksy/StubHandle.name|{}name[0]
         final fun <get-name>(): kotlin/String? // dev.mokksy.mokksy/StubHandle.name.<get-name>|<get-name>(){}[0]
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
@@ -715,7 +715,12 @@ public class MokksyServer
          * @return A [StubHandle] for the matching stub.
          * @throws NoSuchElementException if no stub with that name exists.
          * @throws IllegalStateException if multiple stubs share that name.
+         * @deprecated Use [findStubByName] instead, which returns `null` instead of throwing.
          */
+        @Deprecated(
+            message = "Use findStubByName, which returns null instead of throwing",
+            replaceWith = ReplaceWith("findStubByName(name)"),
+        )
         public fun getStub(name: String): StubHandle {
             val matchingStubs =
                 stubRegistry
@@ -744,6 +749,56 @@ public class MokksyServer
          * @return A list of [StubHandle] for every registered stub.
          */
         public fun allStubs(): List<StubHandle> = stubRegistry.getAll().map { StubHandle(it) }
+
+        /**
+         * Finds a registered stub by its stable unique identifier.
+         *
+         * Unlike [getStub], this method returns `null` instead of throwing when
+         * no stub matches, and does not require the stub to have a name.
+         *
+         * @param id The unique identifier returned from [StubHandle.id] at registration time.
+         * @return A [StubHandle] for the matching stub, or `null` if not found.
+         */
+        public fun findStubById(id: StubId): StubHandle? =
+            stubRegistry.findById(id)?.let { StubHandle(it) }
+
+        /**
+         * Finds a registered stub by its human-readable name.
+         *
+         * Unlike [getStub], this method returns `null` instead of throwing when
+         * no stub matches or when multiple stubs share the same name.
+         *
+         * @param name The name assigned at stub registration.
+         * @return A [StubHandle] for the first matching stub, or `null` if not found.
+         */
+        public fun findStubByName(name: String): StubHandle? =
+            stubRegistry.findByName(name)?.let { StubHandle(it) }
+
+        /**
+         * Finds the first registered stub matching [predicate], or `null` if none match.
+         *
+         * Use this for arbitrary filtering that goes beyond exact name or id lookup:
+         * ```kotlin
+         * mokksy.findStub { it.matchCount() == 0 && it.name?.startsWith("test-") == true }
+         * ```
+         *
+         * @return A [StubHandle] for the first matching stub in registration order, or `null`.
+         */
+        @ExperimentalMokksyApi
+        public fun findStub(predicate: StubPredicate): StubHandle? =
+            allStubs().firstOrNull { predicate.test(it) }
+
+        /**
+         * Finds all registered stubs matching [predicate].
+         *
+         * Returns an empty list if no stubs match. Order follows [allStubs] — by priority
+         * descending, then creation order ascending.
+         *
+         * @return A list of [StubHandle] matching the predicate; empty if no match.
+         */
+        @ExperimentalMokksyApi
+        public fun findStubs(predicate: StubPredicate): List<StubHandle> =
+            allStubs().filter { predicate.test(it) }
 
         private fun ensureJournalAvailable() {
             check(configuration.journalMode != JournalMode.NONE) {

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Stub.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Stub.kt
@@ -11,6 +11,16 @@ import io.ktor.server.routing.RoutingRequest
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Stable unique identifier for a registered stub.
+ *
+ * Generated automatically at stub creation — every stub has a unique [StubId]
+ * regardless of whether an optional [StubConfiguration.name] was assigned.
+ */
+public typealias StubId = String
 
 /**
  * Represents a mapping between an inbound [RequestSpecification] and an outbound response definition.
@@ -28,8 +38,9 @@ import kotlin.concurrent.atomics.incrementAndFetch
  *          This includes headers, body, and HTTP status code, which are applied to the HTTP response.
  * @author Konstantin Pavlov
  */
-@OptIn(ExperimentalAtomicApi::class)
+@OptIn(ExperimentalAtomicApi::class, ExperimentalUuidApi::class)
 internal data class Stub<P : Any, T : Any>(
+    val id: StubId = Uuid.random().toString(),
     val configuration: StubConfiguration,
     val requestSpecification: RequestSpecification<P>,
     val responseDefinitionSupplier: ResponseDefinitionSupplier<T>,
@@ -120,7 +131,12 @@ internal data class Stub<P : Any, T : Any>(
         call: ApplicationCall,
         verbose: Boolean,
         routingRequest: RoutingRequest,
-        responseListener: (suspend (RecordedRequest, AbstractResponseDefinition<*>) -> Unit)? = null,
+        responseListener: (
+            suspend (
+                RecordedRequest,
+                AbstractResponseDefinition<*>,
+            ) -> Unit
+        )? = null,
     ) {
         val responseDefinition = responseDefinitionSupplier.invoke(call)
         responseDefinition.headers?.invoke(call.response.headers)
@@ -135,9 +151,9 @@ internal data class Stub<P : Any, T : Any>(
 
     fun toLogString(): String =
         if (configuration.name?.isNotBlank() == true) {
-            "Stub('${configuration.name}')[config=$configuration requestSpec=${requestSpecification.toLogString()}]"
+            "Stub('${configuration.name}')[$id][config=$configuration requestSpec=${requestSpecification.toLogString()}]"
         } else {
-            "Stub[config=$configuration requestSpec=${requestSpecification.toLogString()}]"
+            "Stub[$id][config=$configuration requestSpec=${requestSpecification.toLogString()}]"
         }
 }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubHandle.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubHandle.kt
@@ -16,6 +16,11 @@ public class StubHandle internal constructor(
     internal val stub: Stub<*, *>,
 ) {
     /**
+     * Stable unique identifier for this stub, generated at creation time.
+     */
+    public val id: StubId get() = stub.id
+
+    /**
      * The optional name assigned at stub registration, or `null` if unnamed.
      */
     public val name: String? get() = stub.configuration.name

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubPredicate.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubPredicate.kt
@@ -1,0 +1,27 @@
+@file:OptIn(ExperimentalMokksyApi::class)
+
+package dev.mokksy.mokksy
+
+/**
+ * SAM-convertible predicate over a [StubHandle].
+ *
+ * Used by [MokksyServer.findStub] and [MokksyServer.findStubs] to filter
+ * registered stubs by arbitrary criteria beyond exact name or id lookup.
+ *
+ * Backed by `fun interface` so it is also SAM-convertible from a Kotlin lambda:
+ * ```kotlin
+ * mokksy.findStubs { it.matchCount() == 0 && it.name?.startsWith("test-") == true }
+ * ```
+ *
+ * Java callers can use a lambda expression:
+ * ```java
+ * mokksy.findStubs(stub -> stub.matchCount() == 0);
+ * ```
+ */
+@ExperimentalMokksyApi
+public fun interface StubPredicate {
+    /**
+     * Returns `true` to include this [StubHandle] in the result set.
+     */
+    public fun test(stub: StubHandle): Boolean
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
@@ -47,6 +47,12 @@ internal class StubRegistry {
      */
     fun add(stub: Stub<*, *>) {
         stubs.update { current ->
+            val name = stub.configuration.name
+            if (!name.isNullOrBlank()) {
+                require(current.none { it.configuration.name == name }) {
+                    "A stub with name '$name' is already registered: ${stub.toLogString()}"
+                }
+            }
             val index = current.binarySearch(stub, StubComparator)
             require(index < 0) { "Duplicate stub detected: ${stub.toLogString()}" }
             current.add(-(index + 1), stub)
@@ -110,6 +116,18 @@ internal class StubRegistry {
      * Returns a snapshot of all registered stubs.
      */
     fun getAll(): List<Stub<*, *>> = stubs.value
+
+    /**
+     * Finds a stub by its human-readable name, or `null` if no stub has that name.
+     */
+    fun findByName(name: String): Stub<*, *>? =
+        stubs.value.firstOrNull { it.configuration.name == name }
+
+    /**
+     * Finds a stub by its stable unique identifier, or `null` if no stub has that id.
+     */
+    fun findById(id: StubId): Stub<*, *>? =
+        stubs.value.firstOrNull { it.id == id }
 
     // region Private helpers
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
@@ -121,13 +121,16 @@ internal class StubRegistry {
      * Finds a stub by its human-readable name, or `null` if no stub has that name.
      */
     fun findByName(name: String): Stub<*, *>? =
-        stubs.value.firstOrNull { it.configuration.name == name }
+        if (name.isBlank()) {
+            null
+        } else {
+            stubs.value.firstOrNull { it.configuration.name == name }
+        }
 
     /**
      * Finds a stub by its stable unique identifier, or `null` if no stub has that id.
      */
-    fun findById(id: StubId): Stub<*, *>? =
-        stubs.value.firstOrNull { it.id == id }
+    fun findById(id: StubId): Stub<*, *>? = stubs.value.firstOrNull { it.id == id }
 
     // region Private helpers
 

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
@@ -535,7 +535,8 @@ public class Mokksy(
         replaceWith = ReplaceWith("findStubByName(name)"),
     )
     public fun getStub(name: String): StubHandle =
-        @Suppress("DEPRECATION") delegate.getStub(name)
+        @Suppress("DEPRECATION")
+        delegate.getStub(name)
 
     /**
      * Finds a registered stub by its stable unique identifier.

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
@@ -3,15 +3,17 @@ package dev.mokksy
 import dev.mokksy.Mokksy.Companion.create
 import dev.mokksy.mokksy.BuildingStep
 import dev.mokksy.mokksy.DEFAULT_HOST
+import dev.mokksy.mokksy.ExperimentalMokksyApi
 import dev.mokksy.mokksy.JavaBuildingStep
 import dev.mokksy.mokksy.JavaRequestSpecificationBuilder
 import dev.mokksy.mokksy.MokksyServer
+import dev.mokksy.mokksy.RequestListener
 import dev.mokksy.mokksy.StubConfiguration
 import dev.mokksy.mokksy.StubHandle
+import dev.mokksy.mokksy.StubId
+import dev.mokksy.mokksy.StubPredicate
 import dev.mokksy.mokksy.loadStubsFromEnv
 import dev.mokksy.mokksy.loadStubsFromFile
-import dev.mokksy.mokksy.ExperimentalMokksyApi
-import dev.mokksy.mokksy.RequestListener
 import dev.mokksy.mokksy.request.RecordedRequest
 import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import dev.mokksy.mokksy.start
@@ -526,8 +528,46 @@ public class Mokksy(
      *
      * @throws NoSuchElementException if no stub with that name exists.
      * @throws IllegalStateException if multiple stubs share that name.
+     * @deprecated Use [findStubByName] instead, which returns `null` instead of throwing.
      */
-    public fun getStub(name: String): StubHandle = delegate.getStub(name)
+    @Deprecated(
+        message = "Use findStubByName, which returns null instead of throwing",
+        replaceWith = ReplaceWith("findStubByName(name)"),
+    )
+    public fun getStub(name: String): StubHandle =
+        @Suppress("DEPRECATION") delegate.getStub(name)
+
+    /**
+     * Finds a registered stub by its stable unique identifier.
+     *
+     * Unlike [getStub], this method returns `null` instead of throwing when
+     * no stub matches, and does not require the stub to have a name.
+     */
+    public fun findStubById(id: StubId): StubHandle? = delegate.findStubById(id)
+
+    /**
+     * Finds a registered stub by its human-readable name.
+     *
+     * Unlike [getStub], this method returns `null` instead of throwing when
+     * no stub matches or when multiple stubs share the same name.
+     */
+    public fun findStubByName(name: String): StubHandle? = delegate.findStubByName(name)
+
+    /**
+     * Finds the first registered stub matching [predicate], or `null` if none match.
+     *
+     * @see MokksyServer.findStub
+     */
+    @ExperimentalMokksyApi
+    public fun findStub(predicate: StubPredicate): StubHandle? = delegate.findStub(predicate)
+
+    /**
+     * Finds all registered stubs matching [predicate]. Returns an empty list if none match.
+     *
+     * @see MokksyServer.findStubs
+     */
+    @ExperimentalMokksyApi
+    public fun findStubs(predicate: StubPredicate): List<StubHandle> = delegate.findStubs(predicate)
 
     /** Returns a snapshot of all registered stubs. */
     public fun allStubs(): List<StubHandle> = delegate.allStubs()

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyMatchingIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyMatchingIT.kt
@@ -34,7 +34,7 @@ internal class BodyMatchingIT : AbstractIT() {
         // given
         val path = "/predicate-$seed"
         mokksy
-            .post(name = "predicate", requestType = Input::class) {
+            .post(name = "predicate-$seed", requestType = Input::class) {
                 path(path)
 
                 bodyMatchesPredicate {
@@ -72,7 +72,7 @@ internal class BodyMatchingIT : AbstractIT() {
         // given
         val path = "/predicate-$seed"
         mokksy
-            .post(name = "predicate", requestType = Input::class) {
+            .post(name = "predicate-$seed", requestType = Input::class) {
                 path(path)
                 bodyContains(
                     Json.encodeToString(input),

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BuildingStepTest.kt
@@ -7,6 +7,7 @@ import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.get
@@ -44,10 +45,12 @@ internal class BuildingStepTest {
 
     @Test
     fun `Should handle respondsWith`() {
-        subject.respondsWith<Output> {
+        val handle = subject.respondsWith<Output> {
             httpStatus = expectedHttpStatus
         }
 
+        handle.id shouldNotBe null
+        handle.name shouldBe name
         verifyStub()
     }
 

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
@@ -9,7 +9,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.get
 import io.ktor.client.request.put
@@ -139,8 +141,9 @@ internal class MokksyServerIT : AbstractIT() {
 
     // endregion
 
-    // region getStub
+    // region getStub (deprecated, retained for backward-compat regression)
 
+    @Suppress("DEPRECATION")
     @Test
     fun `getStub returns named stub handle`() {
         val expected =
@@ -153,6 +156,7 @@ internal class MokksyServerIT : AbstractIT() {
         mokksy.getStub("named-stub").name shouldBe expected.name
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `getStub throws when stub not found`() {
         val error =
@@ -164,24 +168,101 @@ internal class MokksyServerIT : AbstractIT() {
     }
 
     @Test
-    fun `getStub throws when multiple stubs share the same name`() {
+    fun `duplicate stub name throws at registration`() {
         mokksy.get(name = "duplicate-stub", requestType = String::class) {
             path("/duplicate-stub-a-$seed")
         } respondsWith {
             body = "a"
         }
-        mokksy.post(name = "duplicate-stub", requestType = String::class) {
-            path("/duplicate-stub-b-$seed")
-        } respondsWith {
-            body = "b"
-        }
-
         val error =
-            shouldThrow<IllegalStateException> {
-                mokksy.getStub("duplicate-stub")
+            shouldThrow<IllegalArgumentException> {
+                mokksy.post(name = "duplicate-stub", requestType = String::class) {
+                    path("/duplicate-stub-b-$seed")
+                } respondsWith {
+                    body = "b"
+                }
             }
 
-        error.message shouldContain "Expected exactly one stub named 'duplicate-stub'"
+        error.message shouldContain "A stub with name 'duplicate-stub' is already registered"
+    }
+
+    @Test
+    fun `findStubById returns handle for registered stub`() {
+        val handle =
+            mokksy.get { path("/find-by-id-$seed") } respondsWith {
+                body = "ok"
+            }
+        mokksy.findStubById(handle.id) shouldNotBeNull {
+            id shouldBe handle.id
+            name shouldBe null
+        }
+    }
+
+    @Test
+    fun `findStubById returns null for unknown id`() {
+        mokksy.findStubById("nonexistent") shouldBe null
+    }
+
+    @Test
+    fun `findStubByName returns handle for named stub`() {
+        mokksy.get(name = "findable", requestType = String::class) {
+            path("/find-by-name-$seed")
+        } respondsWith {
+            body = "ok"
+        }
+        mokksy.findStubByName("findable") shouldNotBeNull {
+            name shouldBe "findable"
+        }
+    }
+
+    @Test
+    fun `findStubByName returns null for unknown name`() {
+        mokksy.findStubByName("nonexistent") shouldBe null
+    }
+
+    // endregion
+
+    // region findStub / findStubs (predicate)
+
+    @OptIn(ExperimentalMokksyApi::class)
+    @Test
+    fun `findStub with predicate returns first match`() {
+        mokksy.get { path("/predicate-first-$seed") } respondsWith { body = "ok" }
+        mokksy.get { path("/predicate-second-$seed") } respondsWith { body = "ok" }
+
+        mokksy.findStub { it.id.isNotEmpty() } shouldNotBe null
+    }
+
+    @OptIn(ExperimentalMokksyApi::class)
+    @Test
+    fun `findStub with predicate returns null when no match`() {
+        mokksy.get { path("/no-match-$seed") } respondsWith { body = "ok" }
+
+        mokksy.findStub { it.name == "no-such-name" } shouldBe null
+    }
+
+    @OptIn(ExperimentalMokksyApi::class)
+    @Test
+    fun `findStubs with predicate returns all matches`() {
+        mokksy.get(name = "match-a-$seed", requestType = String::class) {
+            path("/match-a-$seed")
+        } respondsWith { body = "a" }
+        mokksy.get(name = "match-b-$seed", requestType = String::class) {
+            path("/match-b-$seed")
+        } respondsWith { body = "b" }
+        mokksy.get(name = "other-$seed", requestType = String::class) {
+            path("/other-$seed")
+        } respondsWith { body = "other" }
+
+        mokksy.findStubs { it.name?.startsWith("match-") == true } shouldHaveSize 2
+    }
+
+    @OptIn(ExperimentalMokksyApi::class)
+    @Test
+    fun `findStubs with predicate returns empty list when no match`() {
+        mokksy.get { path("/nothing-$seed") } respondsWith { body = "ok" }
+
+        mokksy.findStubs { it.name == "missing" } shouldBe emptyList()
     }
 
     // endregion

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/MokksyServerIT.kt
@@ -224,7 +224,6 @@ internal class MokksyServerIT : AbstractIT() {
 
     // region findStub / findStubs (predicate)
 
-    @OptIn(ExperimentalMokksyApi::class)
     @Test
     fun `findStub with predicate returns first match`() {
         mokksy.get { path("/predicate-first-$seed") } respondsWith { body = "ok" }
@@ -233,7 +232,6 @@ internal class MokksyServerIT : AbstractIT() {
         mokksy.findStub { it.id.isNotEmpty() } shouldNotBe null
     }
 
-    @OptIn(ExperimentalMokksyApi::class)
     @Test
     fun `findStub with predicate returns null when no match`() {
         mokksy.get { path("/no-match-$seed") } respondsWith { body = "ok" }
@@ -241,7 +239,6 @@ internal class MokksyServerIT : AbstractIT() {
         mokksy.findStub { it.name == "no-such-name" } shouldBe null
     }
 
-    @OptIn(ExperimentalMokksyApi::class)
     @Test
     fun `findStubs with predicate returns all matches`() {
         mokksy.get(name = "match-a-$seed", requestType = String::class) {
@@ -257,7 +254,6 @@ internal class MokksyServerIT : AbstractIT() {
         mokksy.findStubs { it.name?.startsWith("match-") == true } shouldHaveSize 2
     }
 
-    @OptIn(ExperimentalMokksyApi::class)
     @Test
     fun `findStubs with predicate returns empty list when no match`() {
         mokksy.get { path("/nothing-$seed") } respondsWith { body = "ok" }

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubHandleTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubHandleTest.kt
@@ -4,6 +4,7 @@ package dev.mokksy.mokksy
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 
@@ -17,6 +18,21 @@ class StubHandleTest {
             ),
         ).name shouldBe "named"
         StubHandle(createStub<String, String>(requestType = String::class)).name shouldBe null
+    }
+
+    @Test
+    fun `id delegates to stub id and is never null`() {
+        val stub = createStub<String, String>(requestType = String::class)
+        val handle = StubHandle(stub)
+        handle.id shouldBe stub.id
+        handle.id shouldNotBe null
+    }
+
+    @Test
+    fun `id is auto-generated for every stub`() {
+        val handle1 = StubHandle(createStub<String, String>(requestType = String::class))
+        val handle2 = StubHandle(createStub<String, String>(requestType = String::class))
+        handle1.id shouldNotBe handle2.id
     }
 
     @Test

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
@@ -82,6 +82,73 @@ class StubRegistryTest {
                     registry.add(s1)
                 }
             }
+
+        @Test
+        fun `should throw on duplicate name`() =
+            runTest {
+                val registry = StubRegistry()
+                registry.add(
+                    createStub<String, String>(
+                        name = "dup-name",
+                        requestType = String::class,
+                    ),
+                )
+
+                assertFailsWith<IllegalArgumentException> {
+                    registry.add(
+                        createStub<String, String>(
+                            name = "dup-name",
+                            requestType = String::class,
+                        ),
+                    )
+                }
+            }
+
+        @Test
+        fun `findByName returns stub when name matches`() =
+            runTest {
+                val registry = StubRegistry()
+                val stub =
+                    createStub<String, String>(
+                        name = "target",
+                        requestType = String::class,
+                    )
+                registry.add(stub)
+                registry.findByName("target") shouldBe stub
+            }
+
+        @Test
+        fun `findByName returns null when name does not match`() =
+            runTest {
+                val registry = StubRegistry()
+                registry.add(
+                    createStub<String, String>(
+                        name = "other",
+                        requestType = String::class,
+                    ),
+                )
+                registry.findByName("nonexistent") shouldBe null
+            }
+
+        @Test
+        fun `findById returns stub when id matches`() =
+            runTest {
+                val registry = StubRegistry()
+                val stub =
+                    createStub<String, String>(requestType = String::class)
+                registry.add(stub)
+                registry.findById(stub.id) shouldBe stub
+            }
+
+        @Test
+        fun `findById returns null when id does not match`() =
+            runTest {
+                val registry = StubRegistry()
+                registry.add(
+                    createStub<String, String>(requestType = String::class),
+                )
+                registry.findById("nonexistent-id") shouldBe null
+            }
     }
 
     @Nested


### PR DESCRIPTION
#74: Introduce stable stub identifiers and four new lookup methods across Mokksy's public API, replacing the exception-throwing getStub(name) with nullable alternatives. Each stub receives an auto-generated UUID-based id, validated for name uniqueness at registration, and queryable by id, name, or custom predicate.

