### PR TITLE
feat: verbose 404 diagnostic response with typed matchers (#73)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 7
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,11 +1,11 @@
 rootProject.name = "buildSrc"
 
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+    enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                from(files("../gradle/libs.versions.toml"))
+            }
         }
     }
-}

--- a/buildSrc/src/main/kotlin/shadow-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/shadow-convention.gradle.kts
@@ -1,34 +1,34 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-plugins {
+    plugins {
     `maven-publish`
-    id("org.gradle.base")
-    id("com.gradleup.shadow") // https://gradleup.com/shadow
-}
-
-afterEvaluate {
-    // Remove test-related task dependencies added by atomicfu plugin
-    tasks.named<ShadowJar>("shadowJar") {
-        // Clear existing task dependencies
-        setDependsOn(listOf(tasks.named("jvmJar")))
-
-        // Use only main classes, not test classes
-        configurations = listOf(project.configurations.getByName("jvmRuntimeClasspath"))
-
-        // Set input from jvmJar only
-        from(zipTree(tasks.named<Jar>("jvmJar").flatMap { it.archiveFile }))
-
-        minimize {
-            exclude(dependency("kotlin:.*:.*"))
-            exclude(dependency("org.jetbrains.kotlin:.*:.*"))
-            exclude(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-.*:.*"))
-        }
-
-        relocate("io.ktor", "dev.mokksy.relocated.io.ktor")
-        relocate("kotlinx", "dev.mokksy.relocated.kotlinx")
+        id("org.gradle.base")
+        id("com.gradleup.shadow") // https://gradleup.com/shadow
     }
-}
 
-tasks.assemble {
-    dependsOn(tasks.named("shadowJar"))
-}
+    afterEvaluate {
+        // Remove test-related task dependencies added by atomicfu plugin
+        tasks.named<ShadowJar>("shadowJar") {
+            // Clear existing task dependencies
+            setDependsOn(listOf(tasks.named("jvmJar")))
+
+            // Use only main classes, not test classes
+            configurations = listOf(project.configurations.getByName("jvmRuntimeClasspath"))
+
+            // Set input from jvmJar only
+            from(zipTree(tasks.named<Jar>("jvmJar").flatMap { it.archiveFile }))
+
+            minimize {
+                exclude(dependency("kotlin:.*:.*"))
+                exclude(dependency("org.jetbrains.kotlin:.*:.*"))
+                exclude(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-.*:.*"))
+            }
+
+            relocate("io.ktor", "dev.mokksy.relocated.io.ktor")
+            relocate("kotlinx", "dev.mokksy.relocated.kotlinx")
+        }
+    }
+
+    tasks.assemble {
+        dependsOn(tasks.named("shadowJar"))
+    }

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -850,6 +850,7 @@ public class dev/mokksy/mokksy/request/RequestSpecification {
 	public final fun getMethod ()Lio/kotest/matchers/Matcher;
 	public final fun getPath ()Lio/kotest/matchers/Matcher;
 	public final fun getPriority ()I
+	public final fun getQueryParameters ()Ljava/util/List;
 }
 
 public class dev/mokksy/mokksy/request/RequestSpecificationBuilder {
@@ -877,6 +878,9 @@ public class dev/mokksy/mokksy/request/RequestSpecificationBuilder {
 	public final fun path (Lio/kotest/matchers/Matcher;)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
 	public final fun path (Ljava/lang/String;)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
 	public final fun priority (I)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
+	public final fun queryParam (Ljava/lang/String;Ljava/lang/String;)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
+	public final fun queryParam (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
+	public final fun queryParamAbsent (Ljava/lang/String;)Ldev/mokksy/mokksy/request/RequestSpecificationBuilder;
 	protected final fun setMethod (Lio/kotest/matchers/Matcher;)V
 	public final fun setPath (Lio/kotest/matchers/Matcher;)V
 	public final fun setPriority (I)V
@@ -1048,7 +1052,7 @@ public class dev/mokksy/mokksy/utils/logger/HttpFormatter {
 	public final fun formatBody (Ljava/lang/Object;Lio/ktor/http/ContentType;)Ljava/lang/String;
 	public static synthetic fun formatBody$default (Ldev/mokksy/mokksy/utils/logger/HttpFormatter;Ljava/lang/Object;Lio/ktor/http/ContentType;ILjava/lang/Object;)Ljava/lang/String;
 	protected final fun getColors ()Ldev/mokksy/mokksy/utils/logger/HttpFormatter$ColorScheme;
-	protected final fun getUseColor ()Z
+	public final fun getUseColor ()Z
 	public final fun header (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public final fun requestLine (Lio/ktor/http/HttpMethod;Ljava/lang/String;)Ljava/lang/String;
 	public final fun responseLine (Ljava/lang/String;Lio/ktor/http/HttpStatusCode;)Ljava/lang/String;

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -643,6 +643,8 @@ open class <#A: kotlin/Any> dev.mokksy.mokksy.request/RequestSpecification { // 
         final fun <get-path>(): io.kotest.matchers/Matcher<kotlin/String>? // dev.mokksy.mokksy.request/RequestSpecification.path.<get-path>|<get-path>(){}[0]
     final val priority // dev.mokksy.mokksy.request/RequestSpecification.priority|{}priority[0]
         final fun <get-priority>(): kotlin/Int // dev.mokksy.mokksy.request/RequestSpecification.priority.<get-priority>|<get-priority>(){}[0]
+    final val queryParameters // dev.mokksy.mokksy.request/RequestSpecification.queryParameters|{}queryParameters[0]
+        final fun <get-queryParameters>(): kotlin.collections/List<io.kotest.matchers/Matcher<io.ktor.http/Parameters>> // dev.mokksy.mokksy.request/RequestSpecification.queryParameters.<get-queryParameters>|<get-queryParameters>(){}[0]
 }
 
 open class <#A: kotlin/Any> dev.mokksy.mokksy.request/RequestSpecificationBuilder { // dev.mokksy.mokksy.request/RequestSpecificationBuilder|null[0]
@@ -682,6 +684,9 @@ open class <#A: kotlin/Any> dev.mokksy.mokksy.request/RequestSpecificationBuilde
     final fun path(io.kotest.matchers/Matcher<kotlin/String>): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.path|path(io.kotest.matchers.Matcher<kotlin.String>){}[0]
     final fun path(kotlin/String): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.path|path(kotlin.String){}[0]
     final fun priority(kotlin/Int): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.priority|priority(kotlin.Int){}[0]
+    final fun queryParam(kotlin/String, kotlin/Function1<kotlin/String?, kotlin/Boolean>): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.queryParam|queryParam(kotlin.String;kotlin.Function1<kotlin.String?,kotlin.Boolean>){}[0]
+    final fun queryParam(kotlin/String, kotlin/String): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.queryParam|queryParam(kotlin.String;kotlin.String){}[0]
+    final fun queryParamAbsent(kotlin/String): dev.mokksy.mokksy.request/RequestSpecificationBuilder<#A> // dev.mokksy.mokksy.request/RequestSpecificationBuilder.queryParamAbsent|queryParamAbsent(kotlin.String){}[0]
 }
 
 open class <#A: kotlin/Any?> dev.mokksy.mokksy.response/ResponseDefinition : dev.mokksy.mokksy.response/AbstractResponseDefinition<#A> { // dev.mokksy.mokksy.response/ResponseDefinition|null[0]

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -1,7 +1,3 @@
-
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.get
-
 plugins {
     alias(libs.plugins.kotlin.serialization)
     `kotlin-multiplatform-convention`
@@ -33,7 +29,6 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotest.assertions.core)
-                api(libs.kotest.assertions.json)
                 api(libs.ktor.server.content.negotiation)
                 api(libs.ktor.server.core)
                 api(project.dependencies.platform(libs.ktor.bom))
@@ -55,6 +50,7 @@ kotlin {
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.server.test.host)
+                implementation(libs.kotest.assertions.json)
             }
         }
 
@@ -65,13 +61,6 @@ kotlin {
         }
 
         jvmMain {
-//            val dockerRuntime: Configuration by configurations.creating {
-//                isTransitive = true
-//            }
-
-//            dependencies {
-//                dockerRuntime("org.slf4j:slf4j-simple:2.0.17")
-//            }
 
             dependencies {
                 implementation(libs.jansi)
@@ -80,7 +69,6 @@ kotlin {
                 implementation(libs.ktor.server.netty)
                 implementation(project.dependencies.platform(libs.netty.bom))
                 compileOnly(libs.ktor.serialization.jackson)
-//                 dockerRuntime(libs.slf4j.simple)
             }
         }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Annotations.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/Annotations.kt
@@ -66,7 +66,8 @@ public annotation class ExperimentalMokksyApi
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
     message =
-        "This API is internal in Mokksy and should not be used. It could be removed or changed without notice.",
+        "This API is internal in Mokksy and should not be used outside. " +
+            "It could be removed or changed without notice.",
 )
 @Target(
     CLASS,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubLookupResult.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubLookupResult.kt
@@ -1,0 +1,30 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy
+
+import dev.mokksy.mokksy.request.MatchResult
+
+/**
+ * Outcome of matching a request against registered stubs.
+ *
+ * - [Matched] — a [Stub] matched the request and should handle it.
+ * - [NotMatched] — no stub matched; [evaluations] provides diagnostics for
+ *   the closest candidates, pairing each [Stub] with its [MatchResult].
+ */
+@InternalMokksyApi
+internal sealed interface StubLookupResult {
+    data class Matched(val stub: Stub<*, *>) : StubLookupResult
+    data class NotMatched(val evaluations: List<StubEvaluation>) : StubLookupResult
+}
+
+/**
+ * Associates a [Stub] with the [MatchResult] from evaluating its request specification.
+ *
+ * Used by [StubLookupResult.NotMatched] to report why each candidate stub
+ * did (or did not) match for diagnostic purposes.
+ */
+@InternalMokksyApi
+internal data class StubEvaluation(
+    val stub: Stub<*, *>,
+    val matchResult: MatchResult,
+)

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
@@ -69,46 +69,54 @@ internal class StubRegistry {
      * If another coroutine already claimed it (lost CAS on an [StubConfiguration.eventuallyRemove]
      * stub), retry from Phase 1 with a fresh snapshot.
      *
-     * @return The matched stub, or `null` if no stub matched.
+     * @return [StubLookupResult.Matched] with the matched stub, or
+     * [StubLookupResult.NotMatched] with per-stub evaluation data when no stub matched.
      */
     suspend fun findMatchingStub(
         request: RoutingRequest,
         verbose: Boolean,
         logger: Logger,
         formatter: HttpFormatter,
-    ): Stub<*, *>? {
+    ): StubLookupResult {
         val formattedRequest = formatRequest(request, verbose, formatter)
 
         // Retries only when an eventuallyRemove stub is claimed by a concurrent coroutine
         // between Phase 1 evaluation and the Phase 2 claim — an extremely rare edge case.
+        // Each retry evaluates a fresh snapshot, and claimMatch succeeds at most once
+        // per stub, so the loop always terminates with a different winner.
         while (true) {
             // Phase 1: snapshot + evaluate outside the lock (suspend I/O runs freely).
-            val candidate =
-                evaluate(stubs.value, request, verbose, logger, formattedRequest)
-                    ?: return null
+            val result = evaluate(stubs.value, request, verbose, logger, formattedRequest)
 
-            // Phase 2: claim the winner (lock held only for this brief step).
-            if (candidate.configuration.eventuallyRemove) {
-                // CAS inside the lock: only one coroutine wins; losers retry Phase 1.
-                val claimed =
-                    mutex.withLock {
-                        candidate.claimMatch().also { won ->
-                            if (won) {
-                                stubs.update { it.remove(candidate) }
-                                if (verbose) {
-                                    logger.debug(
-                                        "Removed used stub: ${candidate.toLogString()}",
-                                    )
+            when (result) {
+                is StubLookupResult.NotMatched -> return result
+                is StubLookupResult.Matched -> {
+                    val stub = result.stub
+
+                    // Phase 2: claim the winner (lock held only for this brief step).
+                    if (stub.configuration.eventuallyRemove) {
+                        // CAS inside the lock: only one coroutine wins; losers retry Phase 1.
+                        val claimed =
+                            mutex.withLock {
+                                stub.claimMatch().also { won ->
+                                    if (won) {
+                                        stubs.update { it.remove(stub) }
+                                        if (verbose) {
+                                            logger.debug(
+                                                "Removed used stub: ${stub.toLogString()}",
+                                            )
+                                        }
+                                    }
                                 }
                             }
-                        }
+                        if (!claimed) continue
+                    } else {
+                        stub.markMatched()
                     }
-                if (!claimed) continue
-            } else {
-                candidate.markMatched()
-            }
 
-            return candidate
+                    return result
+                }
+            }
         }
     }
 
@@ -156,47 +164,40 @@ internal class StubRegistry {
         verbose: Boolean,
         logger: Logger,
         formattedRequest: String,
-    ): Stub<*, *>? {
-        val results =
-            snapshot
-                .filter { !it.configuration.eventuallyRemove || !it.hasBeenMatched() }
-                .map { stub -> stub to stub.requestSpecification.matches(request) }
-
-        if (verbose) {
-            results.forEach { (stub, result) ->
+    ): StubLookupResult {
+        val evaluated = buildList {
+            for (stub in snapshot) {
+                if (stub.configuration.eventuallyRemove && stub.hasBeenMatched()) continue
+                val result = stub.requestSpecification.matches(request)
                 result.exceptionOrNull()?.let { ex ->
-                    logger.warn(
-                        "Failed to evaluate condition for stub: ${stub.toLogString()}. " +
-                            "Request: $formattedRequest",
-                        ex,
-                    )
+                    if (verbose) {
+                        logger.warn(
+                            "Failed to evaluate condition for stub: ${stub.toLogString()}. " +
+                                "Request: $formattedRequest",
+                            ex,
+                        )
+                    }
                 }
+                result.getOrNull()?.let { add(stub to it) }
             }
         }
 
-        val evaluated =
-            results.mapNotNull { (stub, result) -> result.getOrNull()?.let { stub to it } }
         val fullMatches = evaluated.filter { (_, mr) -> mr.matched }
 
         if (fullMatches.isNotEmpty()) {
-            return fullMatches
+            val winner = fullMatches
                 .sortedWith(
                     compareByDescending<Pair<Stub<*, *>, MatchResult>> { (_, r) -> r.score }
                         .thenByDescending { (s, _) -> s.requestSpecification.priority }
                         .thenBy { (s, _) -> s.creationOrder },
                 ).first()
                 .first
+            return StubLookupResult.Matched(winner)
         }
 
-        if (verbose) {
-            evaluated.maxByOrNull { (_, r) -> r.score }?.let { (stub, mr) ->
-                logger.warn(
-                    "No stub matched request. Closest stub: ${stub.toLogString()}\n" +
-                        "Failed matchers: ${mr.failedMatchers.joinToString()}",
-                )
-            }
-        }
-        return null
+        // No full match — build evaluation list for diagnostics
+        val evaluations = evaluated.map { (stub, mr) -> StubEvaluation(stub, mr) }
+        return StubLookupResult.NotMatched(evaluations)
     }
 
     // endregion

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/BodySpecMatchers.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/BodySpecMatchers.kt
@@ -24,12 +24,12 @@ private const val MAX_PART_SIZE: Long = 65535
 internal suspend fun scoreFormMatchers(
     request: ApplicationRequest,
     formSpecs: List<FormBodySpec>,
-): Pair<Int, List<String>> {
+): Pair<Int, List<FailedMatcherDescriptor>> {
     var score = 0
-    val failed = mutableListOf<String>()
+    val failed = mutableListOf<FailedMatcherDescriptor>()
 
     formSpecs.forEachIndexed { index, spec ->
-        val (partScore, partFailed) = scoreFormMatcher(request, spec, "form[$index]")
+        val (partScore, partFailed) = scoreFormMatcher(request, spec, index)
         score += partScore
         failed += partFailed
     }
@@ -40,22 +40,22 @@ internal suspend fun scoreFormMatchers(
 private suspend fun scoreFormMatcher(
     request: ApplicationRequest,
     spec: FormBodySpec,
-    label: String,
-): Pair<Int, List<String>> {
+    index: Int,
+): Pair<Int, List<FailedMatcherDescriptor>> {
     val contentType = request.contentType()
     return when {
         spec.encoding != FormEncoding.URL_ENCODED &&
             contentType.match(ContentType.MultiPart.FormData) -> {
-            scoreMultipartParts(request, spec.parts, label)
+            scoreMultipartParts(request, spec.parts, MatcherCategory.FORM, index)
         }
 
         spec.encoding != FormEncoding.MULTIPART &&
             contentType.match(ContentType.Application.FormUrlEncoded) -> {
-            scoreUrlEncodedParts(request, spec.parts, label)
+            scoreUrlEncodedParts(request, spec.parts, MatcherCategory.FORM, index)
         }
 
         else -> {
-            0 to spec.parts.indices.map { "$label[$it]" }
+            0 to listOf(FailedMatcherDescriptor.Indexed(MatcherCategory.FORM, index))
         }
     }
 }
@@ -63,21 +63,21 @@ private suspend fun scoreFormMatcher(
 internal suspend fun scoreMultipartMatchers(
     request: ApplicationRequest,
     multipartSpecs: List<MultipartBodySpec>,
-): Pair<Int, List<String>> {
+): Pair<Int, List<FailedMatcherDescriptor>> {
     var score = 0
-    val failed = mutableListOf<String>()
+    val failed = mutableListOf<FailedMatcherDescriptor>()
 
     multipartSpecs.forEachIndexed { index, spec ->
-        val label = "multipart[$index]"
         val contentType = request.contentType()
         val boundaryPassed =
             spec.boundaryMatcher
                 ?.test(contentType.parameter("boundary"))
                 ?.passed() != false
         if (!contentType.match(spec.contentType) || !boundaryPassed) {
-            failed += spec.parts.indices.map { "$label[$it]" }
+            failed += FailedMatcherDescriptor.Indexed(MatcherCategory.MULTIPART, index)
         } else {
-            val (partScore, partFailed) = scoreMultipartParts(request, spec.parts, label)
+            val (partScore, partFailed) =
+                scoreMultipartParts(request, spec.parts, MatcherCategory.MULTIPART, index)
             score += partScore
             failed += partFailed
         }
@@ -89,7 +89,7 @@ internal suspend fun scoreMultipartMatchers(
 internal suspend fun scoreByteBodyMatchers(
     request: ApplicationRequest,
     byteBodySpecs: List<ByteBodySpec>,
-): Pair<Int, List<String>> {
+): Pair<Int, List<FailedMatcherDescriptor>> {
     if (byteBodySpecs.isEmpty()) return 0 to emptyList()
 
     val body =
@@ -107,7 +107,7 @@ internal suspend fun scoreByteBodyMatchers(
         }
 
     var score = 0
-    val failed = mutableListOf<String>()
+    val failed = mutableListOf<FailedMatcherDescriptor>()
     val contentType =
         try {
             request.headers[HttpHeaders.ContentType]?.let {
@@ -122,21 +122,20 @@ internal suspend fun scoreByteBodyMatchers(
         }
 
     byteBodySpecs.forEachIndexed { index, spec ->
-        val label = "bytes[$index]"
         if (body == null) {
-            failed += label
+            failed += FailedMatcherDescriptor.Indexed(MatcherCategory.BYTES, index)
             return@forEachIndexed
         }
         if (spec.contentTypeMatcher != null &&
             !spec.contentTypeMatcher.test(contentType).passed()
         ) {
-            failed += label
+            failed += FailedMatcherDescriptor.Indexed(MatcherCategory.BYTES, index)
             return@forEachIndexed
         }
         if (spec.contentMatchers.all { it.matches(body) }) {
             score++
         } else {
-            failed += label
+            failed += FailedMatcherDescriptor.Indexed(MatcherCategory.BYTES, index)
         }
     }
 
@@ -146,8 +145,9 @@ internal suspend fun scoreByteBodyMatchers(
 private suspend fun scoreUrlEncodedParts(
     request: ApplicationRequest,
     specs: List<BodyPartSpec>,
-    label: String,
-): Pair<Int, List<String>> {
+    category: MatcherCategory,
+    outerIndex: Int,
+): Pair<Int, List<FailedMatcherDescriptor>> {
     val parameters =
         try {
             request.call.receiveParameters()
@@ -156,19 +156,20 @@ private suspend fun scoreUrlEncodedParts(
         } catch (e: Exception) {
             request.call.application.log
                 .trace("Unable to receive form parameters: ${e.message}")
-            return 0 to specs.indices.map { "$label[$it]" }
+            null
         }
 
-    var score = 0
-    val failed = mutableListOf<String>()
-    specs.forEachIndexed { index, spec ->
-        if (matchesUrlEncodedPart(parameters, spec)) {
-            score++
-        } else {
-            failed += "$label[$index]"
-        }
+    if (parameters == null) {
+        return 0 to listOf(FailedMatcherDescriptor.Indexed(category, outerIndex))
     }
 
+    val score = specs.count { spec -> matchesUrlEncodedPart(parameters, spec) }
+    val failed =
+        if (score == specs.size) {
+            emptyList()
+        } else {
+            listOf(FailedMatcherDescriptor.Indexed(category, outerIndex))
+        }
     return score to failed
 }
 
@@ -176,8 +177,9 @@ private suspend fun scoreUrlEncodedParts(
 private suspend fun scoreMultipartParts(
     request: ApplicationRequest,
     specs: List<BodyPartSpec>,
-    label: String,
-): Pair<Int, List<String>> {
+    category: MatcherCategory,
+    outerIndex: Int,
+): Pair<Int, List<FailedMatcherDescriptor>> {
     val multipart =
         try {
             request.call.receiveMultipart()
@@ -186,7 +188,7 @@ private suspend fun scoreMultipartParts(
         } catch (e: Exception) {
             request.call.application.log
                 .trace("Unable to receive multipart body for matching: ${e.message}")
-            return 0 to specs.indices.map { "$label[$it]" }
+            return 0 to listOf(FailedMatcherDescriptor.Indexed(category, outerIndex))
         }
 
     val parts = mutableListOf<Pair<PartData, ByteArray?>>()
@@ -200,13 +202,12 @@ private suspend fun scoreMultipartParts(
     } catch (e: Exception) {
         request.call.application.log
             .trace("Unable to read multipart parts: ${e.message}")
-        return 0 to specs.indices.map { "$label[$it]" }
+        return 0 to listOf(FailedMatcherDescriptor.Indexed(category, outerIndex))
     }
 
     var score = 0
-    val failed = mutableListOf<String>()
     try {
-        specs.forEachIndexed { index, spec ->
+        for (spec in specs) {
             val matchingParts =
                 parts.filter { (part, _) ->
                     val partName = part.name ?: part.contentDisposition?.parameter("name")
@@ -214,14 +215,18 @@ private suspend fun scoreMultipartParts(
                 }
             if (matchingParts.any { (part, content) -> matchMultipartPart(part, spec, content) }) {
                 score++
-            } else {
-                failed += "$label[$index]"
             }
         }
     } finally {
         parts.forEach { (part, _) -> part.dispose() }
     }
 
+    val failed =
+        if (score == specs.size) {
+            emptyList()
+        } else {
+            listOf(FailedMatcherDescriptor.Indexed(category, outerIndex))
+        }
     return score to failed
 }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/DiagnosticLogger.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/DiagnosticLogger.kt
@@ -1,0 +1,44 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.InternalMokksyApi
+import dev.mokksy.mokksy.utils.highlight.AnsiColor
+import dev.mokksy.mokksy.utils.highlight.colorize
+import dev.mokksy.mokksy.utils.highlight.isColorSupported
+
+@InternalMokksyApi
+internal object DiagnosticLogger {
+    fun format(
+        stubResults: List<StubMatchResult>,
+        useColor: Boolean = isColorSupported(),
+    ): String =
+        buildString {
+            appendLine()
+            val heading =
+                if (stubResults.size == 1) "Closest stub:" else "Closest ${stubResults.size} stubs:"
+            appendLine(heading.colorize(AnsiColor.STRONGER, useColor))
+            for (stubResult in stubResults) {
+                appendLine(
+                    "Stub: ${stubResult.name}".colorize(AnsiColor.STRONGER, useColor),
+                )
+                for (configured in stubResult.configuredMatchers) {
+                    val failed = findFailedMatcher(configured, stubResult.failedMatchers)
+                    if (failed != null) {
+                        appendLine("  ${"✗".colorize(AnsiColor.RED, useColor)} $configured")
+                        appendLine("      $failed")
+                    } else {
+                        appendLine("  ${"✓".colorize(AnsiColor.GREEN, useColor)} $configured")
+                    }
+                }
+            }
+        }
+
+    private fun findFailedMatcher(
+        configured: String,
+        failedMatchers: List<String>,
+    ): String? {
+        val prefix = configured.substringBefore(":")
+        return failedMatchers.find { it.startsWith("$prefix:") }
+    }
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/DiagnosticResponse.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/DiagnosticResponse.kt
@@ -1,0 +1,48 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.InternalMokksyApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Structured 404 response body returned when no stub matches and
+ * [dev.mokksy.mokksy.ServerConfiguration.verbose] is `true`.
+ *
+ * Note: This format is a diagnostic aid, not a public API contract.
+ * The JSON schema may change without notice.
+ */
+@InternalMokksyApi
+@Serializable
+internal data class DiagnosticResponse(
+    val request: RequestInfo,
+    @SerialName("closestStub")
+    val stubEvaluations: List<StubMatchResult>,
+)
+
+@InternalMokksyApi
+@Serializable
+internal data class RequestInfo(
+    val method: String,
+    val path: String,
+    val headers: Map<String, String>,
+    val body: JsonElement? = null,
+)
+
+/**
+ * Per-stub evaluation result.
+ *
+ * [configuredMatchers] lists the matchers configured on this stub
+ * (e.g., "method: GET", "path: '/api/items'", "headers: Authorization = Bearer token").
+ * [failedMatchers] lists matchers that did not pass with expected vs actual
+ * (e.g., "method: expected GET but was POST", "path: expected '/wrong-path' but was '/actual-path'").
+ */
+@InternalMokksyApi
+@Serializable
+internal data class StubMatchResult(
+    val name: String,
+    val configuredMatchers: List<String>,
+    val failedMatchers: List<String>,
+)

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/FailedMatcherDescriptor.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/FailedMatcherDescriptor.kt
@@ -1,0 +1,17 @@
+package dev.mokksy.mokksy.request
+
+/**
+ * Typed descriptor for a matcher that failed during request evaluation.
+ *
+ * Replaces raw string labels to eliminate string parsing in
+ * [describeFailedMatcher].
+ *
+ * - [Simple] — single-entity matchers (method, path).
+ * - [Indexed] — indexed matchers (headers[0], body[1], multipart[0], …).
+ */
+internal sealed interface FailedMatcherDescriptor {
+    data class Simple(val category: MatcherCategory) : FailedMatcherDescriptor
+    data class Indexed(val category: MatcherCategory, val index: Int) : FailedMatcherDescriptor {
+        override fun toString(): String = "$category[$index]"
+    }
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/MatcherCategory.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/MatcherCategory.kt
@@ -1,0 +1,18 @@
+package dev.mokksy.mokksy.request
+
+internal enum class MatcherCategory {
+    METHOD,
+    PATH,
+    HEADERS,
+    BODY,
+    BODY_STRING {
+        override fun toString() = "bodyString"
+    },
+    COOKIES,
+    QUERY_PARAMS,
+    FORM,
+    MULTIPART,
+    BYTES;
+
+    override fun toString(): String = name.lowercase()
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestHandler.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestHandler.kt
@@ -5,6 +5,7 @@ package dev.mokksy.mokksy.request
 import dev.mokksy.mokksy.InternalMokksyApi
 import dev.mokksy.mokksy.ServerConfiguration
 import dev.mokksy.mokksy.Stub
+import dev.mokksy.mokksy.StubLookupResult
 import dev.mokksy.mokksy.StubRegistry
 import dev.mokksy.mokksy.response.AbstractResponseDefinition
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
@@ -15,6 +16,7 @@ import io.ktor.server.logging.toLogString
 import io.ktor.server.response.respond
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.RoutingRequest
+import kotlinx.coroutines.CancellationException
 
 /**
  * Processes an incoming HTTP request by matching it against available stubs and handling the response.
@@ -41,54 +43,114 @@ internal suspend fun handleRequest(
 ) {
     val request = context.call.request
 
-    val matchedStub: Stub<*, *>? =
-        stubRegistry.findMatchingStub(
-            request = request,
-            verbose = configuration.verbose,
-            logger = application.log,
-            formatter = formatter,
-        )
+    when (
+        val result =
+            stubRegistry.findMatchingStub(
+                request = request,
+                verbose = configuration.verbose,
+                logger = application.log,
+                formatter = formatter,
+            )
+    ) {
+        is StubLookupResult.Matched -> {
+            if (requestJournal.recordsMatched) {
+                requestJournal.recordMatched(RecordedRequest.from(request, matched = true))
+            }
+            handleMatchedStub(
+                matchedStub = result.stub,
+                serverConfig = configuration,
+                application = application,
+                request = request,
+                context = context,
+                formatter = formatter,
+                responseListener = responseListener,
+            )
+        }
 
-    if (matchedStub != null) {
-        if (requestJournal.recordsMatched) {
-            requestJournal.recordMatched(RecordedRequest.from(request, matched = true))
+        is StubLookupResult.NotMatched -> {
+            if (requestJournal.recordsUnmatched) {
+                requestJournal.recordUnmatched(RecordedRequest.from(request, matched = false))
+            }
+            val errorMessage = "No matched mapping for request: ${request.toLogString()}"
+            if (configuration.verbose) {
+                handleVerboseNotFound(
+                    context,
+                    application,
+                    result,
+                    configuration,
+                    formatter,
+                )
+            } else {
+                application.log.warn(
+                    "No matched mapping for request:\n---\n${request.toLogString()}\n---",
+                )
+                context.call.respond(HttpStatusCode.NotFound, errorMessage)
+            }
         }
-        handleMatchedStub(
-            matchedStub = matchedStub,
-            serverConfig = configuration,
-            application = application,
-            request = request,
-            context = context,
-            formatter = formatter,
-            responseListener = responseListener,
-        )
-    } else {
-        if (requestJournal.recordsUnmatched) {
-            requestJournal.recordUnmatched(RecordedRequest.from(request, matched = false))
-        }
-        val errorMessage = "No matched mapping for request: ${request.toLogString()}"
-        if (configuration.verbose) {
-            val availableStubs = stubRegistry.getAll()
-            val availableStubsMessage =
-                if (availableStubs.isNotEmpty()) {
-                    val stubsInfo = availableStubs.joinToString("\n---\n") { it.toLogString() }
-                    "Available stubs:\n$stubsInfo"
-                } else {
-                    "No stubs are available."
-                }
-            application.log.warn(
-                "NO STUBS FOUND for the request:\n---\n${
-                    formatter.formatRequest(request)
-                }\n---\n$availableStubsMessage\n",
-            )
-        } else {
-            application.log.warn(
-                "No matched mapping for request:\n---\n${request.toLogString()}\n---",
-            )
-        }
-        // Send a proper HTTP response when stub not found
-        context.call.respond(HttpStatusCode.NotFound, errorMessage)
     }
+}
+
+@Suppress("LongParameterList", "ThrowsCount")
+private suspend fun handleVerboseNotFound(
+    context: RoutingContext,
+    application: Application,
+    result: StubLookupResult.NotMatched,
+    configuration: ServerConfiguration,
+    formatter: HttpFormatter,
+) {
+    val request = context.call.request
+
+    val bestScore = result.evaluations.maxOfOrNull { it.matchResult.score }
+    val topEvals =
+        if (bestScore != null) {
+            result.evaluations.filter { it.matchResult.score == bestScore }
+        } else {
+            result.evaluations
+        }
+
+    val diagnosticData: Pair<RequestInfo, List<StubMatchResult>>? =
+        try {
+            val requestInfo = extractRequestInfo(context, configuration.json)
+            val stubResults = topEvals.map { it.toStubMatchResult(request) }
+            requestInfo to stubResults
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+
+    val formattedRequest =
+        try {
+            formatter.formatRequest(request)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            "<Unable to format request for diagnostics>"
+        }
+    val formattedDiagnostics =
+        if (diagnosticData != null) {
+            try {
+                DiagnosticLogger.format(diagnosticData.second, formatter.useColor)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                "<Unable to format matcher diagnostics>"
+            }
+        } else {
+            "<Diagnostic response not available>"
+        }
+    application.log.warn(
+        "\n=== No stub matched for request ===\n\n${
+            formattedRequest
+        }\n$formattedDiagnostics",
+    )
+
+    context.call.respond(
+        HttpStatusCode.NotFound,
+        diagnosticData?.let { (requestInfo, stubResults) ->
+            DiagnosticResponse(request = requestInfo, stubEvaluations = stubResults)
+        } ?: "No stub matched and diagnostic response could not be built",
+    )
 }
 
 /**
@@ -120,6 +182,11 @@ private suspend fun handleMatchedStub(
                 }\n---\n${this.toLogString()}",
             )
         }
-        respond(context.call, verbose, routingRequest = request, responseListener = responseListener)
+        respond(
+            call = context.call,
+            verbose = verbose,
+            routingRequest = request,
+            responseListener = responseListener,
+        )
     }
 }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestInfoExtractor.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestInfoExtractor.kt
@@ -1,0 +1,62 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.InternalMokksyApi
+import dev.mokksy.mokksy.utils.highlight.Highlighting
+import io.ktor.server.request.contentType
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.receiveText
+import io.ktor.server.request.uri
+import io.ktor.server.routing.RoutingContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Captures the incoming request for the diagnostic 404 response body.
+ *
+ * Body is best-effort: requires the Ktor `DoubleReceive` plugin.
+ * When absent or already consumed, [RequestInfo.body] will be `null`.
+ * When the content type is JSON, the body is parsed into a [JsonElement] for
+ * structured display; otherwise it is wrapped as a [JsonPrimitive].
+ */
+internal suspend fun extractRequestInfo(
+    context: RoutingContext,
+    json: Json,
+): RequestInfo {
+    val request = context.call.request
+    val contentType = request.contentType()
+    val isJsonBody = Highlighting.isJsonContentType(contentType)
+    val bodyText =
+        try {
+            context.call.receiveText()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    val bodyElement: JsonElement? =
+        bodyText?.ifBlank { null }?.let { text ->
+            if (isJsonBody) {
+                try {
+                    json.parseToJsonElement(text)
+                } catch (_: Exception) {
+                    JsonPrimitive(text)
+                }
+            } else {
+                JsonPrimitive(text)
+            }
+        }
+    return RequestInfo(
+        method = request.httpMethod.value,
+        path = request.uri,
+        headers =
+            request.headers.entries().associate { (key, values) ->
+                key to
+                    values.joinToString(", ")
+            },
+        body = bodyElement,
+    )
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestMatchers.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestMatchers.kt
@@ -10,8 +10,6 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpMethod
 import io.ktor.http.Parameters
 import io.ktor.server.request.RequestCookies
-import kotlin.collections.any
-import kotlin.collections.orEmpty
 import kotlin.jvm.JvmName
 
 /**
@@ -34,6 +32,8 @@ internal fun containsHeader(
                 },
             )
         }
+
+        override fun toString(): String = "$name = $expectedValue"
     }
 
 internal fun cookieMatcher(
@@ -55,6 +55,23 @@ internal fun cookieMatcher(
         }
 
         override fun toString(): String = "cookie('$name')"
+    }
+
+internal fun queryParamMatcher(
+    name: String,
+    predicate: (String?) -> Boolean,
+): Matcher<Parameters> =
+    object : Matcher<Parameters> {
+        override fun test(value: Parameters): MatcherResult {
+            val actualValue = value[name]
+            return MatcherResult(
+                predicate(actualValue),
+                { "Query parameter '$name'='$actualValue' should match '$predicate'" },
+                { "Query parameter '$name'='$actualValue' should NOT match '$predicate'" },
+            )
+        }
+
+        override fun toString(): String = "queryParam('$name')"
     }
 
 /**

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecification.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecification.kt
@@ -2,9 +2,11 @@ package dev.mokksy.mokksy.request
 
 import dev.mokksy.mokksy.MokksyDsl
 import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.string.contain
 import io.ktor.http.Headers
 import io.ktor.http.HttpMethod
+import io.ktor.http.Parameters
 import io.ktor.server.request.RequestCookies
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmSynthetic
@@ -27,12 +29,12 @@ public const val DEFAULT_STUB_PRIORITY: Int = 0
  *
  * @property matched `true` when every defined matcher passed.
  * @property score Number of matchers that passed; higher means more specific.
- * @property failedMatchers Human-readable labels of matchers that did not pass.
+ * @property failedMatchers Descriptors of matchers that did not pass.
  */
 internal data class MatchResult(
     val matched: Boolean,
     val score: Int,
-    val failedMatchers: List<String>,
+    val failedMatchers: List<FailedMatcherDescriptor>,
 )
 
 /**
@@ -68,6 +70,7 @@ public open class RequestSpecification<P : Any> internal constructor(
     public val path: Matcher<String>? = null,
     public val headers: List<Matcher<Headers>> = listOf(),
     public val cookies: List<Matcher<RequestCookies>> = listOf(),
+    public val queryParameters: List<Matcher<Parameters>> = listOf(),
     public val body: List<Matcher<P?>> = listOf(),
     public val bodyString: List<Matcher<String?>> = listOf(),
     internal val formSpecs: List<FormBodySpec> = listOf(),
@@ -84,6 +87,7 @@ public open class RequestSpecification<P : Any> internal constructor(
             if (path != null) appendLine("path: $path")
             if (headers.isNotEmpty()) appendLine("headers: $headers")
             if (cookies.isNotEmpty()) appendLine("cookies: $cookies")
+            if (queryParameters.isNotEmpty()) appendLine("queryParameters: $queryParameters")
             if (body.isNotEmpty()) appendLine("body: $body")
             if (bodyString.isNotEmpty()) appendLine("bodyString: $bodyString")
             if (formSpecs.isNotEmpty()) appendLine("forms: $formSpecs")
@@ -101,6 +105,7 @@ public open class RequestSpecificationBuilder<P : Any>(
     public var path: Matcher<String>? = null
     public val headers: MutableList<Matcher<Headers>> = mutableListOf()
     public val cookies: MutableList<Matcher<RequestCookies>> = mutableListOf()
+    internal val queryParameters: MutableList<Matcher<Parameters>> = mutableListOf()
     public val body: MutableList<Matcher<P?>> = mutableListOf()
     public val bodyString: MutableList<Matcher<String?>> = mutableListOf()
     internal val formSpecs: MutableList<FormBodySpec> = mutableListOf()
@@ -125,7 +130,15 @@ public open class RequestSpecificationBuilder<P : Any>(
 
     public fun bodyContains(vararg strings: String): RequestSpecificationBuilder<P> =
         apply {
-            strings.forEach { this.bodyString += contain(it) }
+            strings.forEach { expected ->
+                this.bodyString +=
+                    object : Matcher<String?> {
+                        override fun test(value: String?): MatcherResult =
+                            contain(expected).test(value)
+
+                        override fun toString(): String = "contain('$expected')"
+                    }
+            }
         }
 
     /**
@@ -223,8 +236,7 @@ public open class RequestSpecificationBuilder<P : Any>(
     public fun cookie(
         name: String,
         value: String,
-    ): RequestSpecificationBuilder<P> =
-        cookie(name) { it == value }
+    ): RequestSpecificationBuilder<P> = cookie(name) { it == value }
 
     /**
      * Requires that the request does not contain a cookie with [name].
@@ -242,6 +254,68 @@ public open class RequestSpecificationBuilder<P : Any>(
      */
     public fun cookieAbsent(name: String): RequestSpecificationBuilder<P> =
         cookie(name) { it == null }
+
+    /**
+     * Requires a query parameter with [name] to match [predicate].
+     *
+     * The predicate receives the decoded parameter value, or `null` when the parameter is absent.
+     *
+     * Example:
+     * ```kotlin
+     * mokksy.get {
+     *     path("/search")
+     *     queryParam("q") { it?.startsWith("kotlin") == true }
+     * }
+     * ```
+     *
+     * @param name Query parameter name.
+     * @param predicate Predicate applied to the parameter value.
+     * @return The same instance of [RequestSpecificationBuilder].
+     */
+    public fun queryParam(
+        name: String,
+        predicate: (String?) -> Boolean,
+    ): RequestSpecificationBuilder<P> =
+        apply {
+            queryParameters += queryParamMatcher(name, predicate)
+        }
+
+    /**
+     * Requires a query parameter with [name] to equal [value].
+     *
+     * Example:
+     * ```kotlin
+     * mokksy.get {
+     *     path("/search")
+     *     queryParam("q", "kotlin")
+     * }
+     * ```
+     *
+     * @param name Query parameter name.
+     * @param value Expected value.
+     * @return The same instance of [RequestSpecificationBuilder].
+     */
+    public fun queryParam(
+        name: String,
+        value: String,
+    ): RequestSpecificationBuilder<P> = queryParam(name) { it == value }
+
+    /**
+     * Requires that the request does not contain a query parameter with [name].
+     *
+     * Example:
+     * ```kotlin
+     * mokksy.get {
+     *     path("/legacy")
+     *     queryParamAbsent("deprecated")
+     * }
+     * ```
+     *
+     * @param name Query parameter name that must be absent.
+     * @return The same instance of [RequestSpecificationBuilder].
+     */
+    public fun queryParamAbsent(name: String): RequestSpecificationBuilder<P> =
+        queryParam(name) { it == null }
 
     public fun bodyString(matcher: Matcher<String?>): RequestSpecificationBuilder<P> =
         apply {
@@ -307,6 +381,7 @@ public open class RequestSpecificationBuilder<P : Any>(
             path = path,
             headers = headers,
             cookies = cookies,
+            queryParameters = queryParameters,
             requestType = requestType,
             body = body,
             bodyString = bodyString,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecificationMatching.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestSpecificationMatching.kt
@@ -24,103 +24,119 @@ internal suspend fun RequestSpecification<*>.matches(
     request: ApplicationRequest,
 ): Result<MatchResult> = this.matchesTyped(request)
 
+@Suppress("LongMethod")
 private suspend fun <P : Any> RequestSpecification<P>.matchesTyped(
     request: ApplicationRequest,
-): Result<MatchResult> =
-    runCatching {
-        var score = 0
-        val failed = mutableListOf<String>()
+): Result<MatchResult> {
+    var score = 0
+    val failed = mutableListOf<FailedMatcherDescriptor>()
 
-        if (method != null) {
-            val (s, f) =
-                scoreSingleMatcher(
-                    method,
-                    request.httpMethod,
-                    "method",
-                    request.call,
-                )
-            score += s
-            failed += f
-        }
-        if (path != null) {
-            val (s, f) =
-                scoreSingleMatcher(
-                    path,
-                    request.path(),
-                    "path",
-                    request.call,
-                )
-            score += s
-            failed += f
-        }
-        if (headers.isNotEmpty()) {
-            val (headersScore, headersFailed) =
-                scoreMatchersSafely(
-                    headers,
-                    request.headers,
-                    "headers",
-                    request.call,
-                )
-            score += headersScore
-            failed += headersFailed
-        }
-        val (cookiesScore, cookiesFailed) = scoreCookieMatchers(request)
-        score += cookiesScore
-        failed += cookiesFailed
-
-        val (bodyScore, bodyFailed) = scoreBodyMatchers(request)
-        score += bodyScore
-        failed += bodyFailed
-
-        val (bodyStringScore, bodyStringFailed) = scoreBodyStringMatchers(request)
-        score += bodyStringScore
-        failed += bodyStringFailed
-
-        val (formScore, formFailed) = scoreFormMatchers(request, formSpecs)
-        score += formScore
-        failed += formFailed
-
-        val (multipartScore, multipartFailed) = scoreMultipartMatchers(request, multipartSpecs)
-        score += multipartScore
-        failed += multipartFailed
-
-        val (byteBodyScore, byteBodyFailed) = scoreByteBodyMatchers(request, byteBodySpecs)
-        score += byteBodyScore
-        failed += byteBodyFailed
-
-        MatchResult(matched = failed.isEmpty(), score = score, failedMatchers = failed)
-    }.onFailure {
-        if (it is CancellationException || it is Error) throw it
+    if (method != null) {
+        val (s, f) =
+            scoreSingleMatcher(
+                method,
+                request.httpMethod,
+                MatcherCategory.METHOD,
+                request.call,
+            )
+        score += s
+        failed += f
     }
+    if (path != null) {
+        val (s, f) =
+            scoreSingleMatcher(
+                path,
+                request.path(),
+                MatcherCategory.PATH,
+                request.call,
+            )
+        score += s
+        failed += f
+    }
+    if (headers.isNotEmpty()) {
+        val (headersScore, headersFailed) =
+            scoreMatchersSafely(
+                headers,
+                request.headers,
+                MatcherCategory.HEADERS,
+                request.call,
+            )
+        score += headersScore
+        failed += headersFailed
+    }
+    val (cookiesScore, cookiesFailed) = scoreCookieMatchers(request)
+    score += cookiesScore
+    failed += cookiesFailed
+
+    val (queryParamsScore, queryParamsFailed) = scoreQueryParameterMatchers(request)
+    score += queryParamsScore
+    failed += queryParamsFailed
+
+    val (bodyScore, bodyFailed) = scoreBodyMatchers(request)
+    score += bodyScore
+    failed += bodyFailed
+
+    val (bodyStringScore, bodyStringFailed) = scoreBodyStringMatchers(request)
+    score += bodyStringScore
+    failed += bodyStringFailed
+
+    val (formScore, formFailed) = scoreFormMatchers(request, formSpecs)
+    score += formScore
+    failed += formFailed
+
+    val (multipartScore, multipartFailed) = scoreMultipartMatchers(request, multipartSpecs)
+    score += multipartScore
+    failed += multipartFailed
+
+    val (byteBodyScore, byteBodyFailed) = scoreByteBodyMatchers(request, byteBodySpecs)
+    score += byteBodyScore
+    failed += byteBodyFailed
+
+    return Result.success(MatchResult(matched = failed.isEmpty(), score = score, failedMatchers = failed))
+}
 
 private fun RequestSpecification<*>.scoreCookieMatchers(
     request: ApplicationRequest,
-): Pair<Int, List<String>> =
+): Pair<Int, List<FailedMatcherDescriptor>> =
     if (cookies.isEmpty()) {
         0 to emptyList()
     } else {
         scoreMatchersSafely(
             cookies,
             request.cookies,
-            "cookies",
+            MatcherCategory.COOKIES,
+            request.call,
+        )
+    }
+
+private fun RequestSpecification<*>.scoreQueryParameterMatchers(
+    request: ApplicationRequest,
+): Pair<Int, List<FailedMatcherDescriptor>> =
+    if (queryParameters.isEmpty()) {
+        0 to emptyList()
+    } else {
+        scoreMatchersSafely(
+            queryParameters,
+            request.queryParameters,
+            MatcherCategory.QUERY_PARAMS,
             request.call,
         )
     }
 
 private suspend fun <P : Any> RequestSpecification<P>.scoreBodyMatchers(
     request: ApplicationRequest,
-): Pair<Int, List<String>> =
+): Pair<Int, List<FailedMatcherDescriptor>> =
     if (body.isEmpty()) {
         0 to emptyList()
     } else {
         receiveBodyOrNull(request)
-            ?.let { scoreMatchersSafely(body, it, "body", request.call) }
-            ?: (0 to body.indices.map { "body[$it]" })
+            ?.let { scoreMatchersSafely(body, it, MatcherCategory.BODY, request.call) }
+            ?: (0 to body.indices.map { FailedMatcherDescriptor.Indexed(MatcherCategory.BODY, it) })
     }
 
 private suspend fun RequestSpecification<*>.scoreBodyStringMatchers(
     request: ApplicationRequest,
-): Pair<Int, List<String>> =
+): Pair<Int, List<FailedMatcherDescriptor>> =
     if (bodyString.isEmpty()) {
         0 to emptyList()
     } else {
@@ -129,11 +145,13 @@ private suspend fun RequestSpecification<*>.scoreBodyStringMatchers(
                 scoreMatchersSafely(
                     bodyString,
                     it,
-                    "bodyString",
+                    MatcherCategory.BODY_STRING,
                     request.call,
                 )
             }
-            ?: (0 to bodyString.indices.map { "bodyString[$it]" })
+            ?: (0 to bodyString.indices.map {
+                FailedMatcherDescriptor.Indexed(MatcherCategory.BODY_STRING, it)
+            })
     }
 
 private suspend fun <P : Any> RequestSpecification<P>.receiveBodyOrNull(
@@ -159,34 +177,38 @@ private suspend fun receiveBodyStringOrNull(request: ApplicationRequest): String
         request.call.receive(type = String::class)
     } catch (e: CancellationException) {
         throw e
-    } catch (e: Exception) {
+    } catch (e: ContentTransformationException) {
         request.call.application.log
-            .debug(
-                "Unable to read body as string for matching. " +
-                    "Make sure the Ktor `DoubleReceive` plugin is installed. ${e.message}",
-                e,
-            )
+            .trace("Unable to read body as string for matching: ${e.message}")
+        null
+    } catch (e: BadRequestException) {
+        request.call.application.log
+            .trace("Bad request body during string scoring: ${e.message}")
         null
     }
 
 /**
  * Guards a single matcher invocation. Returns `1 to emptyList()` on pass,
- * `0 to listOf(label)` on mismatch or throw.
+ * `0 to listOf(Simple(category))` on mismatch or throw.
  */
 @Suppress("TooGenericExceptionCaught")
 private fun <T> scoreSingleMatcher(
     matcher: Matcher<T>,
     value: T,
-    label: String,
+    category: MatcherCategory,
     call: ApplicationCall,
-): Pair<Int, List<String>> =
+): Pair<Int, List<FailedMatcherDescriptor>> =
     try {
-        if (matcher.test(value).passed()) 1 to emptyList() else 0 to listOf(label)
+        if (matcher.test(value).passed()) {
+            1 to emptyList()
+        } else {
+            0 to listOf(FailedMatcherDescriptor.Simple(category))
+        }
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        call.application.log.debug("Matcher $label threw during scoring: ${e.message}", e)
-        0 to listOf(label)
+        call.application.log.debug("Matcher $category threw during scoring: ${e.message}", e)
+        0 to listOf(FailedMatcherDescriptor.Simple(category))
     }
 
 /**
@@ -197,19 +219,23 @@ private fun <T> scoreSingleMatcher(
 private fun <T> scoreMatchersSafely(
     matchers: List<Matcher<T>>,
     value: T,
-    label: String,
+    category: MatcherCategory,
     call: ApplicationCall,
-): Pair<Int, List<String>> {
+): Pair<Int, List<FailedMatcherDescriptor>> {
     var score = 0
-    val failed = mutableListOf<String>()
+    val failed = mutableListOf<FailedMatcherDescriptor>()
     matchers.forEachIndexed { i, matcher ->
         try {
-            if (matcher.test(value).passed()) score++ else failed += "$label[$i]"
+            if (matcher.test(value).passed()) {
+                score++
+            } else {
+                failed += FailedMatcherDescriptor.Indexed(category, i)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            call.application.log.debug("Matcher $label[$i] threw during scoring: ${e.message}", e)
-            failed += "$label[$i]"
+            call.application.log.debug("Matcher $category[$i] threw during scoring: ${e.message}", e)
+            failed += FailedMatcherDescriptor.Indexed(category, i)
         }
     }
     return score to failed

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/StubMatchResultFactory.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/StubMatchResultFactory.kt
@@ -1,0 +1,200 @@
+@file:OptIn(InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.InternalMokksyApi
+import dev.mokksy.mokksy.StubEvaluation
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+
+internal fun StubEvaluation.toStubMatchResult(
+    request: io.ktor.server.request.ApplicationRequest,
+): StubMatchResult {
+    val spec = stub.requestSpecification
+    return StubMatchResult(
+        name = stub.configuration.name ?: "Stub #${stub.creationOrder}",
+        configuredMatchers = buildConfiguredMatchers(spec),
+        failedMatchers =
+            matchResult.failedMatchers.map { descriptor ->
+                describeFailedMatcher(descriptor, spec, request)
+            },
+    )
+}
+
+private fun buildConfiguredMatchers(spec: RequestSpecification<*>): List<String> =
+    buildList {
+        spec.method?.let { add("method: $it") }
+        spec.path?.let { add("path: $it") }
+        addIfNotEmpty(spec.headers, "headers")
+        addIfNotEmpty(spec.body, "body") { matcherLabel(it, "body") }
+        addIfNotEmpty(spec.bodyString, "bodyString") { matcherLabel(it, "bodyString") }
+        addIfNotEmpty(spec.cookies, "cookies")
+        addIfNotEmpty(spec.queryParameters, "queryParams")
+        addIfNotEmpty(spec.formSpecs, "form") { f ->
+            val parts = f.parts.joinToString(", ") { it.name }
+            "${f.encoding} parts=[$parts]"
+        }
+        addIfNotEmpty(spec.multipartSpecs, "multipart") { mp ->
+            val parts = mp.parts.joinToString(", ") { it.name }
+            "${mp.contentType} parts=[$parts]"
+        }
+        addIfNotEmpty(spec.byteBodySpecs, "bytes") { bb ->
+            val ct = bb.contentTypeMatcher?.let { matcherLabel(it, "content-type") } ?: "any"
+            "contentType=$ct"
+        }
+    }
+
+private fun <T> MutableList<String>.addIfNotEmpty(
+    items: List<T>,
+    label: String,
+    format: (T) -> String = { it.toString() },
+) {
+    if (items.isNotEmpty()) {
+        add("$label: ${items.joinToString(", ", transform = format)}")
+    }
+}
+
+internal fun matcherLabel(
+    matcher: Any,
+    fallback: String,
+): String {
+    val str = matcher.toString()
+    return if (str.contains('@')) fallback else str
+}
+
+internal fun describeFailedMatcher(
+    descriptor: FailedMatcherDescriptor,
+    spec: RequestSpecification<*>,
+    request: io.ktor.server.request.ApplicationRequest,
+): String =
+    when (descriptor) {
+        is FailedMatcherDescriptor.Simple -> {
+            when (descriptor.category) {
+                MatcherCategory.METHOD -> {
+                    "method: expected ${spec.method} but was ${request.httpMethod.value}"
+                }
+
+                MatcherCategory.PATH -> {
+                    "path: expected ${spec.path} but was ${request.path()}"
+                }
+
+                else -> {
+                    descriptor.category.toString()
+                }
+            }
+        }
+
+        is FailedMatcherDescriptor.Indexed -> {
+            describeIndexedFailedMatcher(descriptor, spec, request)
+        }
+    }
+
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+private fun describeIndexedFailedMatcher(
+    descriptor: FailedMatcherDescriptor.Indexed,
+    spec: RequestSpecification<*>,
+    request: io.ktor.server.request.ApplicationRequest,
+): String =
+    when (descriptor.category) {
+        MatcherCategory.HEADERS -> {
+            val matcherStr = spec.headers.getOrNull(descriptor.index)?.toString()
+            if (matcherStr == null) {
+                "headers: <missing>"
+            } else {
+                val headerName = matcherStr.substringBefore(" = ").trim()
+                val actualValue = request.headers[headerName]
+                if (actualValue != null) {
+                    "headers: expected $matcherStr but was '$actualValue'"
+                } else {
+                    "headers: expected $matcherStr but header was not present"
+                }
+            }
+        }
+
+        MatcherCategory.BODY -> {
+            val str = spec.body.getOrNull(descriptor.index)?.let { matcherLabel(it, "body") }
+            if (str != null) {
+                "body: expected $str"
+            } else {
+                "body: <missing>"
+            }
+        }
+
+        MatcherCategory.BODY_STRING -> {
+            val str =
+                spec.bodyString
+                    .getOrNull(
+                        descriptor.index,
+                    )?.let { matcherLabel(it, "bodyString") }
+            if (str != null) {
+                "bodyString: expected $str"
+            } else {
+                "bodyString: <missing>"
+            }
+        }
+
+        MatcherCategory.MULTIPART -> {
+            val mp = spec.multipartSpecs.getOrNull(descriptor.index)
+            if (mp != null) {
+                val parts = mp.parts.joinToString(", ") { it.name }
+                "multipart: ${mp.contentType} parts=[$parts]"
+            } else {
+                "multipart: <missing>"
+            }
+        }
+
+        MatcherCategory.FORM -> {
+            val f = spec.formSpecs.getOrNull(descriptor.index)
+            if (f != null) {
+                val parts = f.parts.joinToString(", ") { it.name }
+                "form: ${f.encoding} parts=[$parts]"
+            } else {
+                "form: <missing>"
+            }
+        }
+
+        MatcherCategory.BYTES -> {
+            val bb = spec.byteBodySpecs.getOrNull(descriptor.index)
+            if (bb != null) {
+                "bytes: contentType=${
+                    bb.contentTypeMatcher?.let { matcherLabel(it, "content-type") } ?: "any"
+                }"
+            } else {
+                "bytes: <missing>"
+            }
+        }
+
+        MatcherCategory.COOKIES -> {
+            val matcherStr = spec.cookies.getOrNull(descriptor.index)?.toString()
+            if (matcherStr == null) {
+                "cookies: <missing>"
+            } else {
+                val cookieName = matcherStr.removePrefix("cookie('").removeSuffix("')")
+                val actualValue = request.cookies[cookieName]
+                if (actualValue != null) {
+                    "cookies: expected $matcherStr but was '$actualValue'"
+                } else {
+                    "cookies: expected $matcherStr but cookie was not present"
+                }
+            }
+        }
+
+        MatcherCategory.QUERY_PARAMS -> {
+            val matcherStr = spec.queryParameters.getOrNull(descriptor.index)?.toString()
+            if (matcherStr == null) {
+                "queryParams: <missing>"
+            } else {
+                val paramName = matcherStr.removePrefix("queryParam('").removeSuffix("')")
+                val actualValue = request.queryParameters[paramName]
+                if (actualValue != null) {
+                    "queryParams: expected $matcherStr but was '$actualValue'"
+                } else {
+                    "queryParams: expected $matcherStr but parameter was not present"
+                }
+            }
+        }
+
+        else -> {
+            descriptor.category.toString()
+        }
+    }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/logger/HttpFormatter.kt
@@ -42,7 +42,7 @@ private val DefaultJson = Json { ignoreUnknownKeys = true }
 @Suppress("TooManyFunctions")
 public open class HttpFormatter(
     theme: ColorTheme = ColorTheme.LIGHT_ON_DARK,
-    protected val useColor: Boolean = isColorSupported(),
+    public val useColor: Boolean = isColorSupported(),
     private val json: Json = DefaultJson,
 ) {
     /**

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/AbstractIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/AbstractIT.kt
@@ -13,9 +13,10 @@ internal open class AbstractIT(
     private val clientSupplier: (Int) -> HttpClient = {
         createKtorClient(it)
     },
+    private val verbose: Boolean = true,
 ) {
     val mokksy: MokksyServer =
-        MokksyServer(verbose = true) {
+        MokksyServer(verbose = verbose) {
             log.info("Running Mokksy server with ${engine::class.simpleName}")
         }
 

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyDiagnosticIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyDiagnosticIT.kt
@@ -1,0 +1,383 @@
+package dev.mokksy.mokksy
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.parameters
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+
+internal class BodyDiagnosticIT : AbstractIT() {
+    @Test
+    suspend fun `diagnostic response for url-encoded form mismatch`() {
+        val path = "/form-url-mismatch-$seed"
+
+        mokksy.post(StubConfiguration(name = "form-stub")) {
+            path(path)
+            body {
+                form {
+                    field("username", "expected")
+                }
+            }
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result =
+            client.submitForm(
+                url = path,
+                formParameters = parameters { append("username", "actual") },
+            )
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "POST"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "form-stub"
+        } shouldHaveSize 1
+    }
+
+    @Test
+    suspend fun `diagnostic response prefers url-encoded form stub with partial part matches`() {
+        val path = "/form-url-partial-score-$seed"
+
+        mokksy.post(StubConfiguration(name = "partial-form-stub")) {
+            path(path)
+            body {
+                form {
+                    field("first", "one")
+                    field("second", "two")
+                    field("third", "expected")
+                }
+            }
+        } respondsWith {
+            body = "partial"
+        }
+
+        mokksy.post(StubConfiguration(name = "less-relevant-url-form-stub")) {
+            path(path)
+            queryParam("hint", "less")
+            body {
+                form {
+                    field("missing", "value")
+                }
+            }
+        } respondsWith {
+            body = "less"
+        }
+
+        val result =
+            client.submitForm(
+                url = "$path?hint=less",
+                formParameters =
+                    parameters {
+                        append("first", "one")
+                        append("second", "two")
+                        append("third", "actual")
+                    },
+            )
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        closestStubNames(json) shouldContainExactly listOf("partial-form-stub")
+    }
+
+    @Test
+    suspend fun `diagnostic response for multipart form mismatch`() {
+        val path = "/form-multipart-mismatch-$seed"
+
+        mokksy.post(StubConfiguration(name = "multipart-form-stub")) {
+            path(path)
+            body {
+                form {
+                    field("locale", "expected")
+                }
+            }
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result =
+            client.post(path) {
+                setBody(
+                    MultiPartFormDataContent(
+                        formData { append("locale", "actual") },
+                    ),
+                )
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "POST"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "multipart-form-stub"
+        } shouldHaveSize 1
+    }
+
+    @Test
+    suspend fun `diagnostic response prefers multipart form stub with partial part matches`() {
+        val path = "/form-multipart-partial-score-$seed"
+
+        mokksy.post(StubConfiguration(name = "partial-multipart-form-stub")) {
+            path(path)
+            body {
+                form {
+                    field("first", "one")
+                    field("second", "two")
+                    field("third", "expected")
+                }
+            }
+        } respondsWith {
+            body = "partial"
+        }
+
+        mokksy.post(StubConfiguration(name = "less-relevant-multipart-form-stub")) {
+            path(path)
+            queryParam("hint", "less")
+            body {
+                form {
+                    field("missing", "value")
+                }
+            }
+        } respondsWith {
+            body = "less"
+        }
+
+        val result =
+            client.post("$path?hint=less") {
+                setBody(
+                    MultiPartFormDataContent(
+                        formData {
+                            append("first", "one")
+                            append("second", "two")
+                            append("third", "actual")
+                        },
+                    ),
+                )
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        closestStubNames(json) shouldContainExactly listOf("partial-multipart-form-stub")
+    }
+
+    @Test
+    suspend fun `diagnostic response for file mismatch`() {
+        val path = "/file-mismatch-$seed"
+
+        mokksy.post(StubConfiguration(name = "file-stub")) {
+            path(path)
+            body {
+                form {
+                    file("avatar") {
+                        filename("expected.jpg")
+                        contentType(ContentType.Image.JPEG)
+                    }
+                }
+            }
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result =
+            client.post(path) {
+                setBody(
+                    MultiPartFormDataContent(
+                        formData { append("avatar", "actual.png") },
+                    ),
+                )
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "POST"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "file-stub"
+        } shouldHaveSize 1
+    }
+
+    @Test
+    suspend fun `diagnostic response for body byte mismatch`() {
+        val path = "/bytes-mismatch-$seed"
+        val payload = "expected-bytes".encodeToByteArray()
+
+        mokksy.post(StubConfiguration(name = "bytes-stub")) {
+            path(path)
+            body {
+                bytes(payload)
+            }
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result =
+            client.post(path) {
+                contentType(ContentType.Application.OctetStream)
+                setBody("actual-bytes".encodeToByteArray())
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "POST"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "bytes-stub"
+        } shouldHaveSize 1
+    }
+
+    @Test
+    suspend fun `diagnostic response for multipart data mismatch`() {
+        val path = "/multipart-data-mismatch-$seed"
+
+        mokksy.post(StubConfiguration(name = "multipart-stub")) {
+            path(path)
+            body {
+                multipart("multipart/mixed") {
+                    part("part1") {
+                        contentType("text/plain")
+                        text { it == "expected" }
+                    }
+                }
+            }
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result =
+            client.post(path) {
+                setBody(
+                    MultiPartFormDataContent(
+                        formData { append("part1", "actual") },
+                    ),
+                )
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "POST"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "multipart-stub"
+        } shouldHaveSize 1
+    }
+
+    @Test
+    suspend fun `diagnostic response prefers multipart data stub with partial part matches`() {
+        val path = "/multipart-data-partial-score-$seed"
+        val boundary = "PartialScoreBoundary"
+
+        mokksy.post(StubConfiguration(name = "partial-multipart-stub")) {
+            path(path)
+            body {
+                multipart("multipart/mixed") {
+                    part("first") { text("one") }
+                    part("second") { text("two") }
+                    part("third") { text("expected") }
+                }
+            }
+        } respondsWith {
+            body = "partial"
+        }
+
+        mokksy.post(StubConfiguration(name = "less-relevant-multipart-data-stub")) {
+            path(path)
+            queryParam("hint", "less")
+            body {
+                multipart("multipart/mixed") {
+                    part("missing") { text("value") }
+                }
+            }
+        } respondsWith {
+            body = "less"
+        }
+
+        val result =
+            client.post("$path?hint=less") {
+                setBody(
+                    MultiPartFormDataContent(
+                        formData {
+                            append(
+                                "first",
+                                "one".encodeToByteArray(),
+                                Headers.build {
+                                    append(
+                                        HttpHeaders.ContentDisposition,
+                                        "form-data; name=\"first\"",
+                                    )
+                                },
+                            )
+                            append(
+                                "second",
+                                "two".encodeToByteArray(),
+                                Headers.build {
+                                    append(
+                                        HttpHeaders.ContentDisposition,
+                                        "form-data; name=\"second\"",
+                                    )
+                                },
+                            )
+                            append(
+                                "third",
+                                "actual".encodeToByteArray(),
+                                Headers.build {
+                                    append(
+                                        HttpHeaders.ContentDisposition,
+                                        "form-data; name=\"third\"",
+                                    )
+                                },
+                            )
+                        },
+                        boundary = boundary,
+                        contentType =
+                            ContentType.MultiPart.Mixed.withParameter(
+                                "boundary",
+                                boundary,
+                            ),
+                    ),
+                )
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        closestStubNames(json) shouldContainExactly listOf("partial-multipart-stub")
+    }
+
+    @Test
+    suspend fun `diagnostic response for query parameter mismatch`() {
+        val path = "/query-param-mismatch-$seed"
+
+        mokksy.get(StubConfiguration(name = "query-stub")) {
+            path(path)
+            queryParam("q", "expected")
+        } respondsWith {
+            body = "ok"
+        }
+
+        val result = client.get("$path?q=actual")
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val json = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        json["request"]!!.jsonObject["method"]!!.jsonPrimitive.content shouldBe "GET"
+        json["closestStub"]!!.jsonArray.filter {
+            it.jsonObject["name"]!!.jsonPrimitive.content == "query-stub"
+        } shouldHaveSize 1
+    }
+
+    private fun closestStubNames(json: kotlinx.serialization.json.JsonObject): List<String> =
+        json["closestStub"]!!
+            .jsonArray
+            .map { it.jsonObject["name"]!!.jsonPrimitive.content }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyNotMatchingIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/BodyNotMatchingIT.kt
@@ -1,14 +1,23 @@
 package dev.mokksy.mokksy
 
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
@@ -29,7 +38,6 @@ internal class BodyNotMatchingIT : AbstractIT() {
 
     @Test
     suspend fun `should fail when not bodyContains`() {
-        // given
         val path = "/predicate-$seed"
         mokksy
             .post(name = "predicate", Input::class) {
@@ -40,16 +48,14 @@ internal class BodyNotMatchingIT : AbstractIT() {
             }.respondsWith(Output::class) {
                 body = expectedResponse
                 httpStatus = HttpStatusCode.Created
-                headers += "Foo" to "bar" // list style
+                headers += "Foo" to "bar"
             }
-        // when
         val result =
             client.post(path) {
                 contentType(ContentType.Application.Json)
-                setBody(Json.encodeToString(input))
+                setBody(input)
             }
 
-        // then
         result.status shouldBe HttpStatusCode.NotFound
 
         val unexpectedForPath = mokksy.findAllUnexpectedRequests().filter { it.uri == path }
@@ -78,5 +84,166 @@ internal class BodyNotMatchingIT : AbstractIT() {
             }
 
         result.status shouldBe HttpStatusCode.NotFound
+    }
+
+    @Test
+    suspend fun `returns verbose diagnostic JSON when no stub matches`() {
+        val path = "/diagnostic-$seed"
+
+        mokksy.post(StubConfiguration(name = "token-stub")) {
+            path(path)
+            bodyContains("expected-token")
+        } respondsWith { body = "ok" }
+
+        mokksy.get(StubConfiguration(name = "auth-stub")) {
+            path("/other-$seed")
+            containsHeader("X-Api-Key", "secret")
+        } respondsWith { body = "authorized" }
+
+        val result =
+            client.post(path) {
+                contentType(ContentType.Application.Json)
+                setBody("""{"token": "wrong"}""")
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+
+        val actualObj = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        val headersJson =
+            Json.encodeToString(
+                JsonElement.serializer(),
+                actualObj["request"]!!.jsonObject["headers"]!!,
+            )
+
+        val ourEvals =
+            actualObj["closestStub"]!!
+                .jsonArray
+                .filter { it.jsonObject["name"]!!.jsonPrimitive.content == "token-stub" }
+
+        val filteredResponse =
+            buildJsonObject {
+                put("request", actualObj["request"]!!)
+                put("closestStub", buildJsonArray { ourEvals.forEach { add(it) } })
+            }
+
+        Json.encodeToString(filteredResponse) shouldEqualJson """
+        {
+          "request": {
+            "method": "POST",
+            "path": "$path",
+            "body": {"token": "wrong"},
+            "headers": $headersJson
+          },
+            "closestStub": [
+            {
+              "name": "token-stub",
+              "configuredMatchers": ["method: POST", "path: '$path'", "bodyString: contain('expected-token')"],
+              "failedMatchers": ["bodyString: expected contain('expected-token')"]
+            }
+          ]
+        }
+        """
+    }
+
+    @Test
+    suspend fun `diagnostic response lists per-stub failed matchers`() {
+        val path = "/failed-matchers-$seed"
+
+        mokksy.get(StubConfiguration(name = "secured-get")) {
+            path("/wrong-path")
+            containsHeader("Authorization", "Bearer token")
+        } respondsWith { body = "protected" }
+
+        val result = client.get(path)
+
+        result.status shouldBe HttpStatusCode.NotFound
+
+        val actualObj = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        val headersJson =
+            Json.encodeToString(
+                JsonElement.serializer(),
+                actualObj["request"]!!.jsonObject["headers"]!!,
+            )
+
+        val ourEvals =
+            actualObj["closestStub"]!!
+                .jsonArray
+                .filter { it.jsonObject["name"]!!.jsonPrimitive.content == "secured-get" }
+
+        val filteredResponse =
+            buildJsonObject {
+                put("request", actualObj["request"]!!)
+                put("closestStub", buildJsonArray { ourEvals.forEach { add(it) } })
+            }
+
+        Json.encodeToString(filteredResponse) shouldEqualJson """
+        {
+          "request": {
+            "method": "GET",
+            "path": "$path",
+            "headers": $headersJson
+          },
+            "closestStub": [
+            {
+              "name": "secured-get",
+              "configuredMatchers": ["method: GET", "path: '/wrong-path'", "headers: Authorization = Bearer token"],
+              "failedMatchers": ["path: expected '/wrong-path' but was $path", "headers: expected Authorization = Bearer token but header was not present"]
+            }
+          ]
+        }
+        """
+    }
+
+    @Test
+    suspend fun `diagnostic response includes request info and stub evaluations`() {
+        val path = "/concrete-$seed"
+
+        mokksy.post(StubConfiguration(name = "concrete-stub")) {
+            path(path)
+            bodyContains("expected")
+        } respondsWith { body = "ok" }
+
+        val result =
+            client.post(path) {
+                contentType(ContentType.Application.Json)
+                setBody("""{"actual": "value"}""")
+            }
+
+        result.status shouldBe HttpStatusCode.NotFound
+
+        val actualObj = Json.parseToJsonElement(result.bodyAsText()).jsonObject
+        val headersJson =
+            Json.encodeToString(
+                actualObj["request"]!!.jsonObject["headers"]!!,
+            )
+
+        val ourEvals =
+            requireNotNull(actualObj["closestStub"])
+                .jsonArray
+                .filter { it.jsonObject["name"]!!.jsonPrimitive.content == "concrete-stub" }
+
+        val filteredResponse =
+            buildJsonObject {
+                put("request", actualObj["request"]!!)
+                put("closestStub", buildJsonArray { ourEvals.forEach { add(it) } })
+            }
+
+        Json.encodeToString(filteredResponse) shouldEqualJson """
+        {
+          "request": {
+            "method": "POST",
+            "path": "$path",
+            "body": {"actual": "value"},
+            "headers": $headersJson
+          },
+            "closestStub": [
+            {
+              "name": "concrete-stub",
+              "configuredMatchers": ["method: POST", "path: '$path'", "bodyString: contain('expected')"],
+              "failedMatchers": ["bodyString: expected contain('expected')"]
+            }
+          ]
+        }
+        """
     }
 }

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/NonVerboseNotFoundIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/NonVerboseNotFoundIT.kt
@@ -1,0 +1,33 @@
+package dev.mokksy.mokksy
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import org.junit.jupiter.api.Test
+
+internal class NonVerboseNotFoundIT : AbstractIT(verbose = false) {
+
+    @Test
+    suspend fun `returns plain text 404 when verbose is false`() {
+        val path = "/non-verbose-$seed"
+
+        mokksy.post {
+            path("/other-$seed")
+            bodyContains("never-match")
+        } respondsWith { body = "ok" }
+
+        val result = client.post(path) {
+            contentType(ContentType.Application.Json)
+            setBody("""{"key": "value"}""")
+        }
+
+        result.status shouldBe HttpStatusCode.NotFound
+        val body = result.bodyAsText()
+        body.startsWith("No matched mapping for request") shouldBe true
+        (body.first() != '{') shouldBe true
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
@@ -5,6 +5,7 @@ package dev.mokksy.mokksy
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.server.routing.RoutingRequest
 import io.ktor.util.logging.Logger
 import io.mockk.impl.annotations.MockK
@@ -182,7 +183,7 @@ class StubRegistryTest {
                             HttpFormatter(),
                     )
 
-                matched shouldBe highPrio
+                matched.shouldBeInstanceOf<StubLookupResult.Matched>().stub shouldBe highPrio
                 highPrio.hasBeenMatched() shouldBe true
                 lowPrio.hasBeenMatched() shouldBe false
             }
@@ -216,7 +217,7 @@ class StubRegistryTest {
                             HttpFormatter(),
                     )
 
-                matched shouldBe first
+                matched.shouldBeInstanceOf<StubLookupResult.Matched>().stub shouldBe first
             }
 
         @Test
@@ -241,7 +242,7 @@ class StubRegistryTest {
                         formatter =
                             HttpFormatter(),
                     )
-                matched1 shouldBe removable
+                matched1.shouldBeInstanceOf<StubLookupResult.Matched>().stub shouldBe removable
                 removable.hasBeenMatched() shouldBe true
 
                 // Next time it should not be present
@@ -253,7 +254,7 @@ class StubRegistryTest {
                         formatter =
                             HttpFormatter(),
                     )
-                matched2 shouldBe null
+                matched2 shouldBe StubLookupResult.NotMatched(emptyList())
                 registry.getAll().isEmpty() shouldBe true
             }
 
@@ -286,7 +287,7 @@ class StubRegistryTest {
                         formatter = HttpFormatter(),
                     )
 
-                result shouldBe null
+                result shouldBe StubLookupResult.NotMatched(emptyList())
             }
     }
 
@@ -361,8 +362,9 @@ class StubRegistryTest {
                     }
                 val results = jobs.awaitAll()
 
-                results.filterNotNull().size shouldBe count
-                results.toSet().size shouldBe count // All unique
+                val matched = results.filterIsInstance<StubLookupResult.Matched>()
+                matched.size shouldBe count
+                matched.map { it.stub }.toSet().size shouldBe count // All unique
                 registry.getAll().shouldBeEmpty()
             }
     }

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/request/DiagnosticLoggerTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/request/DiagnosticLoggerTest.kt
@@ -1,0 +1,211 @@
+@file:OptIn(dev.mokksy.mokksy.InternalMokksyApi::class)
+
+package dev.mokksy.mokksy.request
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlin.test.Test
+
+internal class DiagnosticLoggerTest {
+    private fun formatLog(stubResults: List<StubMatchResult>) =
+        DiagnosticLogger.format(
+            stubResults = stubResults,
+            useColor = false,
+        )
+
+    @Test
+    fun `shows failed matchers`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "my-stub",
+                            configuredMatchers = listOf("method: POST", "path: '/test'"),
+                            failedMatchers = listOf("path: expected '/test' but was /actual"),
+                        ),
+                    ),
+            )
+
+        log shouldContain "Closest stub:"
+        log shouldContain "Stub: my-stub"
+        log shouldContain "  ✓ method: POST"
+        log shouldContain "  ✗ path: '/test'"
+        log shouldContain "path: expected '/test' but was /actual"
+    }
+
+    @Test
+    fun `does not show received body on bodyString mismatch`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "token-stub",
+                            configuredMatchers =
+                                listOf(
+                                    "method: POST",
+                                    "path: '/test'",
+                                    "bodyString: contain(expected-token)",
+                                ),
+                            failedMatchers =
+                                listOf(
+                                    "bodyString: expected contain(expected-token)",
+                                ),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✓ method: POST"
+        log shouldContain "  ✓ path: '/test'"
+        log shouldContain "  ✗ bodyString: contain(expected-token)"
+        log shouldContain "bodyString: expected contain(expected-token)"
+        log shouldNotContain "received:"
+    }
+
+    @Test
+    fun `does not show received body on body mismatch with plain text`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "body-stub",
+                            configuredMatchers = listOf("body: PredicateMatcher(...)"),
+                            failedMatchers = listOf("body: expected PredicateMatcher(...)"),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✗ body: PredicateMatcher(...)"
+        log shouldContain "body: expected PredicateMatcher(...)"
+        log shouldNotContain "received:"
+    }
+
+    @Test
+    fun `shows header mismatch detail`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "header-stub",
+                            configuredMatchers =
+                                listOf(
+                                    "method: GET",
+                                    "headers: Authorization = Bearer token",
+                                ),
+                            failedMatchers =
+                                listOf(
+                                    "headers: expected Authorization = Bearer token but header was not present",
+                                ),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✓ method: GET"
+        log shouldContain "  ✗ headers: Authorization = Bearer token"
+        log shouldContain
+            "headers: expected Authorization = Bearer token but header was not present"
+    }
+
+    @Test
+    fun `shows multiple closest stubs when they tie`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "stub-a",
+                            configuredMatchers = listOf("method: GET"),
+                            failedMatchers = listOf("path: expected '/a' but was /test"),
+                        ),
+                        StubMatchResult(
+                            name = "stub-b",
+                            configuredMatchers = listOf("method: GET"),
+                            failedMatchers = listOf("path: expected '/b' but was /test"),
+                        ),
+                    ),
+            )
+
+        log shouldContain "Closest 2 stubs:"
+        log shouldContain "Stub: stub-a"
+        log shouldContain "Stub: stub-b"
+        log shouldContain "  ✓ method: GET"
+    }
+
+    @Test
+    fun `shows cookie mismatch detail`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "cookie-stub",
+                            configuredMatchers =
+                                listOf(
+                                    "method: GET",
+                                    "cookies: cookie('session')",
+                                ),
+                            failedMatchers =
+                                listOf(
+                                    "cookies: expected cookie('session') but cookie was not present",
+                                ),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✓ method: GET"
+        log shouldContain "  ✗ cookies: cookie('session')"
+        log shouldContain "cookies: expected cookie('session') but cookie was not present"
+    }
+
+    @Test
+    fun `does not show received on cookie mismatch`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "cookie-stub",
+                            configuredMatchers =
+                                listOf(
+                                    "method: GET",
+                                    "cookies: cookie('session')",
+                                ),
+                            failedMatchers =
+                                listOf(
+                                    "cookies: expected cookie('session') but cookie was not present",
+                                ),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✓ method: GET"
+        log shouldContain "  ✗ cookies: cookie('session')"
+        log shouldContain "cookies: expected cookie('session') but cookie was not present"
+        log shouldNotContain "received:"
+    }
+
+    @Test
+    fun `does not show received on header mismatch`() {
+        val log =
+            formatLog(
+                stubResults =
+                    listOf(
+                        StubMatchResult(
+                            name = "header-stub",
+                            configuredMatchers = listOf("headers: X-Api-Key = secret"),
+                            failedMatchers =
+                                listOf(
+                                    "headers: expected X-Api-Key = secret but header was not present",
+                                ),
+                        ),
+                    ),
+            )
+
+        log shouldContain "  ✗ headers: X-Api-Key = secret"
+        log shouldContain "headers: expected X-Api-Key = secret but header was not present"
+        log shouldNotContain "received:"
+    }
+}


### PR DESCRIPTION
feat: verbose 404 diagnostic response with typed matchers (#73)

- Structured JSON diagnostic (`DiagnosticResponse`, `StubMatchResult`) on verbose 404 with closest-stub evaluations
- `FailedMatcherDescriptor` sealed interface (`Simple`/`Indexed`) replaces string-based failure tracking
- `MatcherCategory` enum for typed category routing (method, path, headers, body, cookies, queryParams, form, multipart, bytes)
- `DiagnosticLogger` formats console output with ✓/✗ per configured matcher
- `RequestInfoExtractor` captures request info with best-effort body (requires DoubleReceive)
- `StubMatchResultFactory` produces human-readable failure descriptions with actual values (header/cookie/query-param value or "not present")
- Query parameter DSL: `queryParam(name, predicate/value)`, `queryParamAbsent`
- Body matching: narrow exception handling (`ContentTransformationException`, `BadRequestException`), `MAX_PART_SIZE` cap (65535)
- `StubRegistry.evaluate` single-pass, introduces `StubLookupResult.Matched/NotMatched` sealed result
- `handleVerboseNotFound` extracted with try/catch diagnostic construction, plain-text fallback
- Removed `runCatching`+`onFailure` from `matchesTyped` — per-scoring-function exception boundaries
- `HttpFormatter.useColor` visibility relaxed to `public`
- New: `DiagnosticLogger.kt`, `DiagnosticResponse.kt`, `FailedMatcherDescriptor.kt`, `MatcherCategory.kt`, `RequestInfoExtractor.kt`, `StubMatchResultFactory.kt`
- Tests: `BodyDiagnosticIT`, `NonVerboseNotFoundIT`, `DiagnosticLoggerTest`, extended `BodyNotMatchingIT`