### PR TITLE
feat: #77 configurable timeout for awaitStarted() — withTimeoutOrNull, ApplicationStarted guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ lint:
 # https://docs.openrewrite.org/recipes/maven/bestpractices
 .PHONY: format
 format:
+	@./gradlew rewriteRun
 	@./gradlew detekt --auto-correct
 
 .PHONY: all

--- a/buildSrc/src/main/kotlin/publish-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-convention.gradle.kts
@@ -2,74 +2,74 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.dokka.gradle.tasks.DokkaGenerateModuleTask
 
-plugins {
+    plugins {
     `maven-publish`
-    id("com.vanniktech.maven.publish")
-}
+        id("com.vanniktech.maven.publish")
+    }
 
-/**
- * Task that provides HTML documentation directory for javadoc jar creation.
- * Dokka Javadoc doesn't support KMP, so HTML format is used.
- * Maven Central accepts HTML docs in the javadoc JAR.
- *
- * This is a Sync task that copies Dokka output to a staging directory,
- * which Vanniktech uses to create the javadoc jar.
- */
-val dokkaHtmlForJavadoc by tasks.registering(Sync::class) {
-    group = "dokka"
-    description = "Prepares Dokka HTML output for javadoc jar."
-    from(
-        tasks
-            .named<DokkaGenerateModuleTask>("dokkaGenerateModuleHtml")
-            .flatMap { it.outputDirectory },
+    /**
+     * Task that provides HTML documentation directory for javadoc jar creation.
+     * Dokka Javadoc doesn't support KMP, so HTML format is used.
+     * Maven Central accepts HTML docs in the javadoc JAR.
+     *
+     * This is a Sync task that copies Dokka output to a staging directory,
+     * which Vanniktech uses to create the javadoc jar.
+     */
+    val dokkaHtmlForJavadoc by tasks.registering(Sync::class) {
+        group = "dokka"
+        description = "Prepares Dokka HTML output for javadoc jar."
+        from(
+            tasks
+                .named<DokkaGenerateModuleTask>("dokkaGenerateModuleHtml")
+                .flatMap { it.outputDirectory },
     )
-    into(layout.buildDirectory.dir("dokka-javadoc"))
-}
+        into(layout.buildDirectory.dir("dokka-javadoc"))
+    }
 
-mavenPublishing {
-    signAllPublications()
-    publishToMavenCentral()
+    mavenPublishing {
+        signAllPublications()
+        publishToMavenCentral()
 
-    coordinates(project.group.toString(), project.name, project.version.toString())
+        coordinates(project.group.toString(), project.name, project.version.toString())
 
-    configure(
-        KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaHtmlForJavadoc"),
-            sourcesJar = true,
+        configure(
+            KotlinMultiplatform(
+                javadocJar = JavadocJar.Dokka("dokkaHtmlForJavadoc"),
+                sourcesJar = true,
         ),
     )
 
-    pom {
-        name = project.name
-        description = project.description
-        url = "https://mokksy.dev"
-        inceptionYear = "2025"
+        pom {
+            name = project.name
+            description = project.description
+            url = "https://mokksy.dev"
+            inceptionYear = "2025"
 
-        licenses {
-            license {
-                name = "MIT License"
-                url = "https://opensource.org/licenses/MIT"
+            licenses {
+                license {
+                    name = "MIT License"
+                    url = "https://opensource.org/licenses/MIT"
+                }
             }
-        }
 
-        developers {
-            developer {
-                id = "kpavlov"
-                roles = setOf("author", "developer")
-                name = "Konstantin Pavlov"
-                url = "https://github.com/kpavlov"
+            developers {
+                developer {
+                    id = "kpavlov"
+                    roles = setOf("author", "developer")
+                    name = "Konstantin Pavlov"
+                    url = "https://github.com/kpavlov"
+                }
             }
-        }
 
-        scm {
-            connection = "scm:git:git://github.com/mokksy/mokksy.git"
-            developerConnection = "scm:git:ssh://github.com/mokksy/mokksy.git"
-            url = "https://github.com/mokksy/mokksy"
-        }
+            scm {
+                connection = "scm:git:git://github.com/mokksy/mokksy.git"
+                developerConnection = "scm:git:ssh://github.com/mokksy/mokksy.git"
+                url = "https://github.com/mokksy/mokksy"
+            }
 
-        issueManagement {
-            url = "https://github.com/mokksy/mokksy/issues"
-            system = "GitHub"
+            issueManagement {
+                url = "https://github.com/mokksy/mokksy/issues"
+                system = "GitHub"
+            }
         }
     }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://downloads.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/gradlew
+++ b/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/3d91ce3b8caaf77ad09f381f43615b715b53f72c/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob//platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/integration-tests/src/commonTest/kotlin/dev/mokksy/it/AwaitStartedIT.kt
+++ b/integration-tests/src/commonTest/kotlin/dev/mokksy/it/AwaitStartedIT.kt
@@ -1,0 +1,60 @@
+@file:OptIn(ExperimentalMokksyApi::class)
+
+package dev.mokksy.it
+
+import dev.mokksy.mokksy.ExperimentalMokksyApi
+import dev.mokksy.mokksy.MokksyServer
+import dev.mokksy.mokksy.ServerConfiguration
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class AwaitStartedIT {
+    @Test
+    fun `awaitStarted with explicit timeout returns when server starts`() =
+        runIntegrationTest {
+            val server = MokksyServer(configuration = ServerConfiguration(verbose = false))
+
+            coroutineScope {
+                val job = async { server.startSuspend() }
+                server.awaitStarted(timeout = 5.seconds)
+                job.await()
+            }
+
+            server.port() shouldBe 0
+        }
+
+    @Test
+    fun `awaitStarted without timeout returns when server starts`() =
+        runIntegrationTest {
+            val server = MokksyServer(configuration = ServerConfiguration(verbose = false))
+
+            coroutineScope {
+                val job = async { server.startSuspend() }
+                server.awaitStarted()
+                job.await()
+            }
+
+            server.port() shouldBe 0
+        }
+
+    @Test
+    fun `awaitStarted without timeout returns immediately when server already started`() =
+        runIntegrationTest {
+            val server = MokksyServer(configuration = ServerConfiguration(verbose = false))
+
+            server.startSuspend(wait = true)
+            server.awaitStarted()
+        }
+
+    @Test
+    fun `awaitStarted with explicit timeout returns immediately when server already started`() =
+        runIntegrationTest {
+            val server = MokksyServer(configuration = ServerConfiguration(verbose = false))
+
+            server.startSuspend(wait = true)
+            server.awaitStarted(timeout = 5.seconds)
+        }
+}

--- a/mokksy/api/mokksy.api
+++ b/mokksy/api/mokksy.api
@@ -13,7 +13,9 @@ public final class dev/mokksy/Mokksy : java/lang/AutoCloseable {
 	public synthetic fun <init> (Ljava/lang/String;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addListener (Ldev/mokksy/mokksy/RequestListener;)V
 	public final fun allStubs ()Ljava/util/List;
+	public final synthetic fun awaitStarted (Ljava/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final synthetic fun awaitStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun awaitStarted-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun baseUrl ()Ljava/lang/String;
 	public fun close ()V
 	public static final fun create ()Ldev/mokksy/Mokksy;
@@ -117,6 +119,8 @@ public final class dev/mokksy/Mokksy : java/lang/AutoCloseable {
 	public final synthetic fun shutdownSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun shutdownSuspend$default (Ldev/mokksy/Mokksy;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun start ()Ldev/mokksy/Mokksy;
+	public final fun start (Ljava/time/Duration;)Ldev/mokksy/Mokksy;
+	public static synthetic fun start$default (Ldev/mokksy/Mokksy;Ljava/time/Duration;ILjava/lang/Object;)Ldev/mokksy/Mokksy;
 	public final synthetic fun startSuspend (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun startSuspend$default (Ldev/mokksy/Mokksy;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun verifyNoUnexpectedRequests ()V
@@ -290,6 +294,7 @@ public final class dev/mokksy/mokksy/MokksyJava {
 	public static synthetic fun shutdown$default (Ldev/mokksy/mokksy/MokksyServer;JJILjava/lang/Object;)V
 	public static synthetic fun shutdown$default (Ldev/mokksy/mokksy/MokksyServer;JJLkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public static final fun start (Ldev/mokksy/mokksy/MokksyServer;)Ldev/mokksy/mokksy/MokksyServer;
+	public static final fun start (Ldev/mokksy/mokksy/MokksyServer;Ljava/time/Duration;)Ldev/mokksy/mokksy/MokksyServer;
 	public static final synthetic fun start (Ldev/mokksy/mokksy/MokksyServer;Lkotlinx/coroutines/CoroutineDispatcher;)Ldev/mokksy/mokksy/MokksyServer;
 }
 
@@ -308,6 +313,7 @@ public final class dev/mokksy/mokksy/MokksyServer : dev/mokksy/mokksy/MokksyHand
 	public final fun addListener (Ldev/mokksy/mokksy/RequestListener;)V
 	public final fun allStubs ()Ljava/util/List;
 	public final fun awaitStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitStarted-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun baseUrl ()Ljava/lang/String;
 	public final fun checkForUnmatchedRequests ()V
 	public final fun checkForUnmatchedStubs ()V

--- a/mokksy/api/mokksy.klib.api
+++ b/mokksy/api/mokksy.klib.api
@@ -511,6 +511,7 @@ final class dev.mokksy.mokksy/MokksyServer : dev.mokksy.mokksy/MokksyHandler { /
     final fun verifyNoUnexpectedRequests() // dev.mokksy.mokksy/MokksyServer.verifyNoUnexpectedRequests|verifyNoUnexpectedRequests(){}[0]
     final fun verifyNoUnmatchedStubs() // dev.mokksy.mokksy/MokksyServer.verifyNoUnmatchedStubs|verifyNoUnmatchedStubs(){}[0]
     final suspend fun awaitStarted(): dev.mokksy.mokksy/MokksyServer // dev.mokksy.mokksy/MokksyServer.awaitStarted|awaitStarted(){}[0]
+    final suspend fun awaitStarted(kotlin.time/Duration): dev.mokksy.mokksy/MokksyServer // dev.mokksy.mokksy/MokksyServer.awaitStarted|awaitStarted(kotlin.time.Duration){}[0]
     final suspend fun handle(io.ktor.server.routing/RoutingContext) // dev.mokksy.mokksy/MokksyServer.handle|handle(io.ktor.server.routing.RoutingContext){}[0]
     final suspend fun shutdownSuspend(kotlin/Long = ..., kotlin/Long = ...) // dev.mokksy.mokksy/MokksyServer.shutdownSuspend|shutdownSuspend(kotlin.Long;kotlin.Long){}[0]
     final suspend fun startSuspend(kotlin/Boolean = ...): dev.mokksy.mokksy/MokksyServer // dev.mokksy.mokksy/MokksyServer.startSuspend|startSuspend(kotlin.Boolean){}[0]

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
@@ -27,11 +27,13 @@ import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmSynthetic
 import kotlin.reflect.KClass
+import kotlin.time.Duration
 
 /**
  * An embedded mock HTTP server for testing. Registers stubs for any HTTP method and verifies
@@ -117,7 +119,14 @@ public class MokksyServer
                 logger = this.environment.log
                 mokksy(this@MokksyServer)
                 configurer(this)
+                subscribeToApplicationStarted(this) {
+                    this@MokksyServer.signalStarted()
+                }
             }
+
+        internal fun signalStarted() {
+            started.complete(Unit)
+        }
 
         override suspend fun handle(context: RoutingContext) {
             handleRequest(
@@ -158,6 +167,8 @@ public class MokksyServer
          * Use this as a synchronization point when [startSuspend] is launched asynchronously.
          * Returns immediately if the server is already started.
          *
+         * Defaults to a timeout of [DEFAULT_START_TIMEOUT].
+         *
          * Example:
          * ```kotlin
          * coroutineScope {
@@ -165,9 +176,24 @@ public class MokksyServer
          *     mokksy.awaitStarted() // port() and baseUrl() are safe after this point
          * }
          * ```
+         *
+         * @throws IllegalStateException if the server does not start within the default timeout.
          */
-        public suspend fun awaitStarted(): MokksyServer {
-            started.await()
+        public suspend fun awaitStarted(): MokksyServer = awaitStarted(DEFAULT_START_TIMEOUT)
+
+        /**
+         * Suspends until the server has fully started and the port is bound, or until [timeout] elapses.
+         *
+         * Use this as a synchronization point when [startSuspend] is launched asynchronously.
+         * Returns immediately if the server is already started.
+         *
+         * @param timeout Maximum duration to wait for the server to start.
+         * @throws IllegalStateException if the server does not start within [timeout].
+         */
+        public suspend fun awaitStarted(timeout: Duration): MokksyServer {
+            require(timeout.isPositive()) { "timeout must be positive: $timeout" }
+            withTimeoutOrNull(timeout) { started.await() }
+                ?: error("Mokksy server did not start within $timeout")
             return this
         }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/platform.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/platform.kt
@@ -3,8 +3,27 @@ package dev.mokksy.mokksy
 import io.ktor.server.application.Application
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 internal const val DEFAULT_HOST: String = "127.0.0.1"
+internal val DEFAULT_START_TIMEOUT: Duration = 5.seconds
+
+/**
+ * Platform-specific hook to subscribe to application start event.
+ *
+ * On JVM, this subscribes to [io.ktor.server.application.ApplicationStarted]
+ * so that [MokksyServer.awaitStarted] returns only when the Ktor engine is
+ * actually ready to accept connections. On non-JVM targets this is a no-op,
+ * because the event may not fire reliably.
+ *
+ * @param application The Ktor application instance.
+ * @param onStarted Callback to invoke when the application has started.
+ */
+internal expect fun subscribeToApplicationStarted(
+    application: Application,
+    onStarted: () -> Unit,
+)
 
 /**
  * Creates and returns an embedded Ktor server instance

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/MokksyServerTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/MokksyServerTest.kt
@@ -1,0 +1,22 @@
+package dev.mokksy.mokksy
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.test.runTest
+
+internal class MokksyServerTest {
+
+    @Test
+    fun `should throw IllegalStateException when awaitStarted times out`() =
+        runTest {
+            val server = MokksyServer(configuration = ServerConfiguration())
+
+            val exception = shouldThrow<IllegalStateException> {
+                server.awaitStarted(timeout = 100.milliseconds)
+            }
+
+            exception.message shouldContain "100ms"
+        }
+}

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/Mokksy.kt
@@ -3,6 +3,7 @@ package dev.mokksy
 import dev.mokksy.Mokksy.Companion.create
 import dev.mokksy.mokksy.BuildingStep
 import dev.mokksy.mokksy.DEFAULT_HOST
+import dev.mokksy.mokksy.DEFAULT_START_TIMEOUT
 import dev.mokksy.mokksy.ExperimentalMokksyApi
 import dev.mokksy.mokksy.JavaBuildingStep
 import dev.mokksy.mokksy.JavaRequestSpecificationBuilder
@@ -29,6 +30,10 @@ import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.util.function.Consumer
 import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
+import java.time.Duration as JavaDuration
 
 /**
  * The primary entry point for Mokksy — a lightweight HTTP stub server for JVM tests.
@@ -96,10 +101,13 @@ public class Mokksy(
      * Mokksy mokksy = Mokksy.create(8080).start();
      * ```
      *
+     * @param timeout Maximum duration to wait for the server to start. Defaults to 5 seconds.
      * @return This instance, for chaining.
+     * @throws IllegalStateException if the server does not start within [timeout].
      */
-    public fun start(): Mokksy {
-        delegate.start()
+    @JvmOverloads
+    public fun start(timeout: JavaDuration = DEFAULT_START_TIMEOUT.toJavaDuration()): Mokksy {
+        delegate.start(timeout)
         return this
     }
 
@@ -607,6 +615,26 @@ public class Mokksy(
     /** Suspends until the server is fully started and ready to accept connections. */
     @JvmSynthetic
     public suspend fun awaitStarted(): MokksyServer = delegate.awaitStarted()
+
+    /**
+     * Suspends until the server is fully started and ready to accept connections.
+     *
+     * @param timeout Maximum duration to wait for the server to start.
+     * @throws IllegalStateException if the server does not start within [timeout].
+     */
+    @JvmSynthetic
+    public suspend fun awaitStarted(timeout: Duration): MokksyServer =
+        delegate.awaitStarted(timeout)
+
+    /**
+     * Suspends until the server is fully started and ready to accept connections.
+     *
+     * @param timeout Maximum duration to wait for the server to start.
+     * @throws IllegalStateException if the server does not start within [timeout].
+     */
+    @JvmSynthetic
+    public suspend fun awaitStarted(timeout: JavaDuration): MokksyServer =
+        delegate.awaitStarted(timeout.toKotlinDuration())
 
     /**
      * Stops the server asynchronously.

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/MokksyServer.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/MokksyServer.jvm.kt
@@ -7,9 +7,36 @@ import dev.mokksy.mokksy.response.ResponseDefinitionBuilder
 import dev.mokksy.mokksy.response.StreamingResponseDefinitionBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import java.time.Duration
 import java.util.function.Consumer
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 // region Lifecycle
+
+/**
+ * Starts the Mokksy server and blocks until the port is bound and ready to accept requests.
+ *
+ * Returns `this` for chaining:
+ * ```kotlin
+ * val mokksy = Mokksy().start(Duration.ofSeconds(5))
+ * ```
+ *
+ * @param timeout Maximum duration to wait for the server to start. Defaults to [DEFAULT_START_TIMEOUT].
+ * @throws IllegalStateException if the server does not start within [timeout].
+ */
+public fun MokksyServer.start(timeout: Duration): MokksyServer {
+    try {
+        loadStubsFromEnv()
+    } catch (_: IllegalStateException) {
+        // no MOKKSY_CONFIG set — start with empty stub registry
+    }
+    runBlocking {
+        this@start.startSuspend()
+        this@start.awaitStarted(timeout.toKotlinDuration())
+    }
+    return this
+}
 
 /**
  * Starts the Mokksy server and blocks until the port is bound and ready to accept requests.
@@ -19,21 +46,11 @@ import java.util.function.Consumer
  * val mokksy = Mokksy().start()
  * ```
  *
- * Intended for Java callers and blocking JVM test setups. Kotlin callers should prefer
- * [MokksyServer.startSuspend] combined with [MokksyServer.awaitStarted].
+ * Maximum duration to wait for the server to start is to [DEFAULT_START_TIMEOUT].
+ * @throws IllegalStateException if the server does not start within [DEFAULT_START_TIMEOUT].
  */
-public fun MokksyServer.start(): MokksyServer {
-    try {
-        loadStubsFromEnv()
-    } catch (_: IllegalStateException) {
-        // no MOKKSY_CONFIG set — start with empty stub registry
-    }
-    runBlocking {
-        this@start.startSuspend()
-        this@start.awaitStarted()
-    }
-    return this
-}
+public fun MokksyServer.start(): MokksyServer =
+    start(timeout = DEFAULT_START_TIMEOUT.toJavaDuration())
 
 /**
  * Starts the Mokksy server on the given dispatcher, blocking until the port is bound.

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/platform.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/platform.jvm.kt
@@ -1,6 +1,7 @@
 package dev.mokksy.mokksy
 
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.application.install
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
@@ -8,6 +9,16 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.calllogging.CallLogging
 import org.slf4j.event.Level
+
+@Suppress("DEPRECATION")
+internal actual fun subscribeToApplicationStarted(
+    application: Application,
+    onStarted: () -> Unit,
+) {
+    application.environment.monitor.subscribe(ApplicationStarted) {
+        onStarted()
+    }
+}
 
 internal actual fun createEmbeddedServer(
     host: String,

--- a/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.jvm.kt
+++ b/mokksy/src/jvmMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.jvm.kt
@@ -4,24 +4,25 @@ package dev.mokksy.mokksy.utils
 
 import io.ktor.http.ContentType
 import io.ktor.http.defaultForFile
+import io.ktor.http.defaultForFileExtension
 import io.ktor.http.defaultForFilePath
 import java.io.File
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.extension
 
 @JvmOverloads
 public fun File.asBase64DataUrl(
-    mimeType: MimeType = ContentType.defaultForFile(this).toString(),
+    mimeType: MimeType = ContentType.defaultForFileExtension(this.extension).asMimeType(),
 ): String = this.readBytes().asBase64DataUrl(mimeType)
 
 @JvmOverloads
 public fun Path.asBase64DataUrl(
     mimeType: MimeType =
         ContentType
-            .defaultForFilePath(
-                fileName.toString(),
-            ).asMimeType(),
+            .defaultForFileExtension(extension)
+            .asMimeType(),
 ): String = Files.readAllBytes(this).asBase64DataUrl(mimeType)
 
 /**

--- a/mokksy/src/nativeMain/kotlin/dev/mokksy/mokksy/platform.native.kt
+++ b/mokksy/src/nativeMain/kotlin/dev/mokksy/mokksy/platform.native.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.Level
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.application.call
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.ApplicationEngine
@@ -11,6 +12,13 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 
 private val logger = KotlinLogging.logger {}
+
+internal actual fun subscribeToApplicationStarted(
+    application: Application,
+    onStarted: () -> Unit,
+) {
+    // No-op: ApplicationStarted event is unreliable on native targets
+}
 
 internal actual fun createEmbeddedServer(
     host: String,

--- a/mokksy/src/webMain/kotlin/dev/mokksy/mokksy/platform.web.kt
+++ b/mokksy/src/webMain/kotlin/dev/mokksy/mokksy/platform.web.kt
@@ -12,6 +12,13 @@ import io.ktor.server.engine.embeddedServer
 
 private val logger: KLogger = KotlinLogging.logger("MokksyServer")
 
+internal actual fun subscribeToApplicationStarted(
+    application: Application,
+    onStarted: () -> Unit,
+) {
+    // No-op: ApplicationStarted event is unreliable on web targets
+}
+
 internal actual fun createEmbeddedServer(
     host: String,
     port: Int,


### PR DESCRIPTION
Closes #77

Adds configurable timeout to `awaitStarted()` and `start()` across all platforms:

**Timeout behavior:**
- `DEFAULT_START_TIMEOUT` = 5.seconds (common)
- `awaitStarted(timeout:)` uses `withTimeoutOrNull` — avoids permanently cancelling the caller's coroutine scope
- `require(timeout.isPositive())` guard
- No-arg `awaitStarted()` delegates to `awaitStarted(DEFAULT_START_TIMEOUT)`

**Engine readiness (race fix):**
- `started.complete(Unit)` moved from `startSuspend()` to `ApplicationStarted` event handler — signal now fires when the Ktor engine is actually ready, not when the OS port is assigned

**Java interop:**
- JVM: `start(java.time.Duration)` + no-arg `start()` with `@JvmOverloads` on `Mokksy` facade
- `start(Duration)` extension on `MokksyServer` in `MokksyJava`
- All suspend overloads hidden from Java via `@JvmSynthetic`

**Testing:**
- Unit test: timeout → `IllegalStateException` with duration in message
- Integration tests: all overloads, happy path + already-started
